### PR TITLE
vox1: use ITK Pool threader to fix intermittent SIGSEGV under load

### DIFF
--- a/implementation/python/voxlogica/primitives/vox1/kernels.py
+++ b/implementation/python/voxlogica/primitives/vox1/kernels.py
@@ -37,8 +37,9 @@ from voxlogica.primitives.default._sequence_math import apply_binary_op
 # modern default. Done once at import, before any filter runs.
 try:
     sitk.ProcessObject.SetGlobalDefaultThreader("Pool")
-except Exception:  # pragma: no cover - older SimpleITK without the setter
-    pass
+except Exception as e:  # pragma: no cover - older SimpleITK without the setter
+    import sys
+    print(f"WARNING: could not set ITK threader to Pool: {e}", file=sys.stderr)
 
 _BASE_IMAGE: sitk.Image | None = None
 _BASE_IMAGE_LOCK = RLock()

--- a/implementation/python/voxlogica/primitives/vox1/kernels.py
+++ b/implementation/python/voxlogica/primitives/vox1/kernels.py
@@ -29,6 +29,17 @@ except Exception:  # pragma: no cover - optional acceleration
 
 from voxlogica.primitives.default._sequence_math import apply_binary_op
 
+# ITK's legacy "Platform" threader spawns and destroys native threads on every
+# filter Execute(); over a long run (thousands of distance-map/morphology calls)
+# that thread churn intermittently segfaults inside ITK under sustained load
+# (captured: SIGSEGV in SignedMaurerDistanceMapImageFilter.Execute via dt). Switch
+# to the persistent thread-pool threader, which reuses a fixed pool and is ITK's
+# modern default. Done once at import, before any filter runs.
+try:
+    sitk.ProcessObject.SetGlobalDefaultThreader("Pool")
+except Exception:  # pragma: no cover - older SimpleITK without the setter
+    pass
+
 _BASE_IMAGE: sitk.Image | None = None
 _BASE_IMAGE_LOCK = RLock()
 _CROSSCORR_BACKEND_ENV = "VOXLOGICA_VOX1_CROSSCORR_BACKEND"


### PR DESCRIPTION
Fixes #15.

## What

Switch ITK's global default threader from the legacy `Platform` backend to the persistent `Pool` thread pool, once at `vox1/kernels.py` import.

```python
sitk.ProcessObject.SetGlobalDefaultThreader("Pool")
```

## Why

`Platform` spawns and tears down native threads on every filter `Execute()`. Over a long run (thousands of distance-map/morphology calls) that thread churn intermittently segfaults inside ITK — captured via `faulthandler` as a SIGSEGV in `SignedMaurerDistanceMapImageFilter.Execute()` reached through `dt`, with the C stack bottoming out in libc pthread frames (a thread-lifecycle fault, not an algorithm bug). See #15 for the full trace and analysis.

`Pool` reuses a fixed thread pool (ITK's modern default), protects every filter, and keeps `dt` multithreaded.

## Validation

The exact 3×16-thread concurrent workload that reproducibly crashed at ~85 min ran **>110 min clean** with this change (~3× the baseline crash exposure, zero faults). `Pool` also parallelizes better (~400% vs ~160% CPU per worker).

## Scope

One file, 11 lines (a comment + a guarded one-liner). No behavior change beyond threading backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
