### PR TITLE
Memoize live results in RAM to avoid duplicate computation

### DIFF
--- a/implementation/python/voxlogica/storage.py
+++ b/implementation/python/voxlogica/storage.py
@@ -467,15 +467,7 @@ class MaterializationStore:
     def get(self, node_id: str) -> Any:
         with self._lock:
             record = self._records.get(node_id)
-            if record is not None and record.value == node_id:
-                if self._backend is not None:
-                    backend_record = self._backend.get_record(node_id)
-                    if backend_record is not None and backend_record.status == MATERIALIZED_STATUS:
-                        return backend_record.value
-                # raise KeyError(f"No materialized record for node {node_id}")
-                return None
             if record is None or record.status != MATERIALIZED_STATUS:
-                # raise KeyError(f"No materialized record for node {node_id}")
                 return None
             return record.value
 
@@ -484,15 +476,14 @@ class MaterializationStore:
             record_metadata = dict(metadata or {})
             val,reason,encoded = can_serialize_value(value)
             format_version = encoded.format_version if encoded is not None else ""
-            vox_type = encoded.vox_type if encoded is not None else ""     
-            if vox_type == "bytes" or vox_type == "overlay" or vox_type == "ndarray" or vox_type == "image":
-                stored_value = node_id
-                # self._backend.put_success(node_id, value, metadata=record_metadata) if self._backend is not None else None
-            else:
-                stored_value = value
-            self._records[node_id] = MaterializationRecord(MATERIALIZED_STATUS, expression, dependencies, stored_value, record_metadata, format_version=format_version, vox_type=vox_type)
-            #if vox_type == "bytes" or vox_type == "ndarray":
-            #    return
+            vox_type = encoded.vox_type if encoded is not None else ""
+            # Keep the live value in RAM so repeated demands for the same node
+            # within a run return the memoized result instead of recomputing it.
+            # Image-like values (image/bytes/ndarray/overlay) used to be replaced
+            # by a node-id placeholder here, which forced a backend round-trip on
+            # every reuse -- and with --no-cache (no backend) a full recomputation,
+            # so a shared image subtree was recomputed once per consumer.
+            self._records[node_id] = MaterializationRecord(MATERIALIZED_STATUS, expression, dependencies, value, record_metadata, format_version=format_version, vox_type=vox_type)
             if self._backend is None or not self._write_through:
                 return
             if not val:

--- a/tests/unit/test_inrun_memo.py
+++ b/tests/unit/test_inrun_memo.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from voxlogica.storage import MaterializationStore
+
+
+@pytest.mark.unit
+def test_image_like_value_is_memoized_in_ram_without_backend() -> None:
+    """An image-like result must stay in RAM so a shared node is computed once.
+
+    Image-like values (here an ndarray) used to be replaced by a node-id
+    placeholder in the in-memory record, so ``get`` returned ``None`` whenever
+    no backend was present (e.g. --no-cache) and the node was recomputed on
+    every reuse. The live value must now be returned directly.
+    """
+    store = MaterializationStore(backend=None, read_through=False, write_through=False)
+    array = np.arange(12, dtype=np.float32).reshape(3, 4)
+
+    store.put("node-image", "expr", [], array, metadata={"source": "runtime"})
+
+    cached = store.get("node-image")
+    assert cached is not None
+    assert np.array_equal(cached, array)
+
+
+@pytest.mark.unit
+def test_scalar_value_round_trips_in_ram_without_backend() -> None:
+    store = MaterializationStore(backend=None, read_through=False, write_through=False)
+    store.put("node-scalar", "expr", [], 42.0, metadata={"source": "runtime"})
+    assert store.get("node-scalar") == 42.0


### PR DESCRIPTION
**Tracking issue:** #14 — fixes defects §2/§3.1 (no in-RAM image memo → recompute under `--no-cache`) and §3.2 (repeated disk deserialize under `--store-db`). Does **not** address §3.3 (double serialize/write) or §4 (node-level parallelism), which stay open in #14.

---

## Summary

First of two stacked PRs addressing the lazy-interpreter caching defects in #14. This one is the minimal correctness fix; the follow-up (#TBD) layers a bounded two-level cache on top.

**Scope:** avoid duplicate computation only. No parallelization.

## The defect

`MaterializationStore.put()` replaced image-like values (`image`/`bytes`/`ndarray`/`overlay`) with a **node-id placeholder** in the in-memory record:

```python
if vox_type in ("bytes", "overlay", "ndarray", "image"):
    stored_value = node_id      # <- real value dropped
else:
    stored_value = value
```

`get()` then had to round-trip to the backend to recover the value. With **no backend (`--no-cache`)** that round-trip returns `None`, so `_evaluate_node_lazy`'s top-level `cache_lookup` misses and the node is **recomputed on every demand**. A node shared by *N* consumers (a diamond DAG over images — exactly the BraTS sweeps) recomputes its whole subtree *N* times. Scalars were unaffected because their real value was kept.

## The fix

Keep the real value in the in-memory record for all types; return it directly from `get()`. Each node is now computed **at most once per run** regardless of backend. With a backend present, reuse also stops re-reading and re-deserializing the payload from disk on every demand.

Two small edits in `storage.py` (`put`, `get`), plus removal of the now-dead placeholder branch.

## Trade-off

Live intermediates are now held in RAM for the duration of the run (previously image-like values were dropped). The stacked follow-up PR bounds this with an LRU memory tier backed by the disk tier — the "two-level cache" of #14.

## Tests

- New `tests/unit/test_inrun_memo.py`: an ndarray result is returned from `get()` with no backend (the exact case that used to recompute), plus a scalar round-trip.
- `test_async_persistence` and the storage/execution unit tests still pass.
- End-to-end CLI run under `--no-cache` verified.

(Pre-existing unrelated failures in `test_default_primitives.py` — `SequenceValue`/`.compute()` API drift — fail identically on `main`.)

Refs #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)