### PR TITLE
Plan expansion + async executor fixes (#20)

### DIFF
--- a/implementation/python/voxlogica/execution_strategy/lazy.py
+++ b/implementation/python/voxlogica/execution_strategy/lazy.py
@@ -239,8 +239,10 @@ class LazyExecutionStrategy(ExecutionStrategy):
         node = prepared.plan.nodes[nodeId]
         expression = node.operator if node.kind != "closure" else {"body": node.attrs.get("body"), "parameter": node.attrs.get("parameter"), "capture_names": node.attrs.get("capture_names"), "function_captures": node.attrs.get("function_captures")}
         dependencies = list(node.args) + [value_id for _, value_id in node.kwargs]
-        if self.results_database is not None:
-            self.results_database.put_success(nodeId, value, metadata={"source": "runtime", "operator": node.operator})
+        # Persist only through the materialization store (its backend is the
+        # results database). A second synchronous results_database.put_success
+        # here would double-write and, for large images, block the event loop on
+        # disk I/O — starving the executor of work. See issue #19.
         if prepared.materialization_store is not None:
             prepared.materialization_store.put(nodeId, expression, dependencies, value, metadata={"source": "runtime", "operator": node.operator})
         prepared.completed_nodes.add(nodeId)
@@ -253,8 +255,6 @@ class LazyExecutionStrategy(ExecutionStrategy):
         id = hash_sequence_item(nodeId,index)
         expression = node.operator if node.kind != "closure" else {"body": node.attrs.get("body"), "parameter": node.attrs.get("parameter"), "capture_names": node.attrs.get("capture_names"), "function_captures": node.attrs.get("function_captures")}
         dependencies = list(node.args) + [value_id for _, value_id in node.kwargs]
-        if self.results_database is not None:
-            self.results_database.put_success(id, value, metadata={"source": "runtime", "operator": node.operator, "index": id})
         prepared.completed_nodes.add(nodeId)
         if self._progress is not None:
             self._progress.update(1)
@@ -529,13 +529,16 @@ class LazyExecutionStrategy(ExecutionStrategy):
                         self._progress.update(1)
 
                 # This node has now consumed its dependencies; free any whose
-                # last consumer has run (kept values stay live in the memo cache).
+                # last consumer has run. Drop the strong ref here and from the
+                # memo tier so peak memory tracks the live frontier, not the plan.
                 for dep in self._get_all_deps(node):
                     remaining = consumers.get(dep, 0)
                     if remaining > 0:
                         consumers[dep] = remaining - 1
                         if consumers[dep] == 0 and dep not in goal_set:
                             prepared.values.pop(dep, None)
+                            if prepared.materialization_store is not None:
+                                prepared.materialization_store.forget(dep)
 
                 new_ready: list[NodeId] = []
                 for child_id in dependents[nid]:

--- a/implementation/python/voxlogica/execution_strategy/lazy.py
+++ b/implementation/python/voxlogica/execution_strategy/lazy.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import Any, Iterable
 import inspect
 import json
+import os
 import pickle
 import time
 import traceback
@@ -30,9 +31,33 @@ from voxlogica.value_model import adapt_runtime_value
 from voxlogica.pod_codec import encode_for_storage
 from voxlogica.lazy.hash import hash_sequence_item
 
+def _default_max_concurrency() -> int:
+    """Max primitive kernels running concurrently in the async executor.
+
+    ITK kernels are internally multithreaded, so a handful already saturate the
+    CPU; the cap's real job is to bound peak memory. Each in-flight image kernel
+    holds a large working set and produces a result that the (single) persistence
+    thread must write to disk before the memo cache can evict it. Too many
+    concurrent producers outrun persistence and the un-evictable results pile up
+    until OOM. Default to the core count; override with VOXLOGICA_MAX_CONCURRENCY.
+    """
+    raw = os.environ.get("VOXLOGICA_MAX_CONCURRENCY")
+    if raw:
+        try:
+            value = int(raw)
+        except ValueError:
+            value = 0
+        if value > 0:
+            return value
+    return os.cpu_count() or 8
+
+
+_MAX_CONCURRENCY = _default_max_concurrency()
+
 # Module-level thread pool: workers call ITK kernels (GIL released → true parallelism).
-# max_workers=None → Python default: min(32, cpu_count + 4).
-_executor = ThreadPoolExecutor(max_workers=None)
+# Sized to the concurrency cap so queued futures don't pin more worker threads than
+# we allow to run.
+_executor = ThreadPoolExecutor(max_workers=_MAX_CONCURRENCY)
 
 _LAZY_SEQUENCE_OPERATORS = {
     "default.map", 
@@ -468,6 +493,9 @@ class LazyExecutionStrategy(ExecutionStrategy):
             return
 
         loop = asyncio.get_running_loop()
+        # Bound concurrent kernel execution: caps peak memory (in-flight working
+        # sets + results awaiting persistence). See _default_max_concurrency.
+        sem = asyncio.Semaphore(_MAX_CONCURRENCY)
 
         async def eval_node(nid: NodeId) -> None:
             nonlocal active, first_error
@@ -479,7 +507,8 @@ class LazyExecutionStrategy(ExecutionStrategy):
                     value = self._build_runtime_closure_from_values_eager(prepared, node)
                 else:
                     # Primitive: run in thread pool so ITK can use all cores (GIL released).
-                    value = await loop.run_in_executor(_executor, self._compute_primitive, prepared, nid)
+                    async with sem:
+                        value = await loop.run_in_executor(_executor, self._compute_primitive, prepared, nid)
 
                 # ── Back in event loop — no preemption ────────────────────────
                 prepared.values[nid] = value

--- a/implementation/python/voxlogica/execution_strategy/lazy.py
+++ b/implementation/python/voxlogica/execution_strategy/lazy.py
@@ -485,83 +485,84 @@ class LazyExecutionStrategy(ExecutionStrategy):
             return
 
         # ── Step 4: async execution ───────────────────────────────────────────
-        active = len(ready)
-        first_error: BaseException | None = None
-        done_event = asyncio.Event()
-        if active == 0:
-            done_event.set()
+        if not ready:
             return
 
+        first_error: BaseException | None = None
         loop = asyncio.get_running_loop()
-        # Bound concurrent kernel execution: caps peak memory (in-flight working
-        # sets + results awaiting persistence). See _default_max_concurrency.
-        sem = asyncio.Semaphore(_MAX_CONCURRENCY)
 
-        async def eval_node(nid: NodeId) -> None:
-            nonlocal active, first_error
-            node = prepared.plan.nodes[nid]
-            try:
-                if node.kind == "constant":
-                    value = node.attrs.get("value")
-                elif node.kind == "closure":
-                    value = self._build_runtime_closure_from_values_eager(prepared, node)
-                else:
-                    # Primitive: run in thread pool so ITK can use all cores (GIL released).
-                    async with sem:
-                        value = await loop.run_in_executor(_executor, self._compute_primitive, prepared, nid)
-
-                # ── Back in event loop — no preemption ────────────────────────
-                prepared.values[nid] = value
-
-                # Closures are not serialisable; constants are trivial. Only cache primitives.
-                if node.kind == "primitive":
-                    if node.operator in _LAZY_SEQUENCE_OPERATORS:
-                        self.cache(prepared, nid, value)
-                        for i, item in enumerate(value):
-                            self.cache_sequence_item(prepared, nid, i, item)
-                    else:
-                        self.cache(prepared, nid, value)
-                else:
-                    # Still mark progress for constants and closures.
-                    prepared.completed_nodes.add(nid)
-                    if self._progress is not None:
-                        self._progress.set_postfix_str(node.operator, refresh=False)
-                        self._progress.update(1)
-
-                # This node has now consumed its dependencies; free any whose
-                # last consumer has run. Drop the strong ref here and from the
-                # memo tier so peak memory tracks the live frontier, not the plan.
-                for dep in self._get_all_deps(node):
-                    remaining = consumers.get(dep, 0)
-                    if remaining > 0:
-                        consumers[dep] = remaining - 1
-                        if consumers[dep] == 0 and dep not in goal_set:
-                            prepared.values.pop(dep, None)
-                            if prepared.materialization_store is not None:
-                                prepared.materialization_store.forget(dep)
-
-                new_ready: list[NodeId] = []
-                for child_id in dependents[nid]:
-                    pending[child_id] -= 1
-                    if pending[child_id] == 0:
-                        new_ready.append(child_id)
-
-                active += len(new_ready) - 1
-                for child_id in new_ready:
-                    asyncio.create_task(eval_node(child_id))
-
-            except Exception as exc:
-                if first_error is None:
-                    first_error = exc
-                active -= 1
-
-            if active == 0:
-                done_event.set()
-
+        # LIFO ready queue + a fixed pool of workers. LIFO drives each pipeline
+        # depth-first to completion before spreading out, so the live (computed
+        # but not-yet-consumed) frontier — and thus peak memory — stays bounded
+        # by the worker count rather than the plan width. The worker count is
+        # the concurrency cap; ITK kernels run in the thread pool. See #20.
+        ready_queue: asyncio.LifoQueue[NodeId] = asyncio.LifoQueue()
         for nid in ready:
-            asyncio.create_task(eval_node(nid))
+            ready_queue.put_nowait(nid)
 
-        await done_event.wait()
+        def finish(nid: NodeId, node: NodeSpec, value: Any) -> None:
+            """Event-loop bookkeeping after a node's value is known."""
+            prepared.values[nid] = value
+
+            if node.kind == "primitive":
+                if node.operator in _LAZY_SEQUENCE_OPERATORS:
+                    self.cache(prepared, nid, value)
+                    for i, item in enumerate(value):
+                        self.cache_sequence_item(prepared, nid, i, item)
+                else:
+                    self.cache(prepared, nid, value)
+            else:
+                # Constants/closures are not persisted; just record progress.
+                prepared.completed_nodes.add(nid)
+                if self._progress is not None:
+                    self._progress.set_postfix_str(node.operator, refresh=False)
+                    self._progress.update(1)
+
+            # This node has consumed its dependencies; free any whose last
+            # consumer has now run, from both prepared.values and the memo tier,
+            # so peak memory tracks the live frontier rather than the whole plan.
+            for dep in self._get_all_deps(node):
+                remaining = consumers.get(dep, 0)
+                if remaining > 0:
+                    consumers[dep] = remaining - 1
+                    if consumers[dep] == 0 and dep not in goal_set:
+                        prepared.values.pop(dep, None)
+                        if prepared.materialization_store is not None:
+                            prepared.materialization_store.forget(dep)
+
+            # Enable children whose dependencies are now all satisfied.
+            for child_id in dependents[nid]:
+                pending[child_id] -= 1
+                if pending[child_id] == 0:
+                    ready_queue.put_nowait(child_id)
+
+        async def worker() -> None:
+            nonlocal first_error
+            while True:
+                nid = await ready_queue.get()
+                try:
+                    if first_error is None:
+                        node = prepared.plan.nodes[nid]
+                        if node.kind == "constant":
+                            value = node.attrs.get("value")
+                        elif node.kind == "closure":
+                            value = self._build_runtime_closure_from_values_eager(prepared, node)
+                        else:
+                            # ITK kernel: run in thread pool (GIL released → real parallelism).
+                            value = await loop.run_in_executor(_executor, self._compute_primitive, prepared, nid)
+                        finish(nid, node, value)
+                except Exception as exc:  # noqa: BLE001
+                    if first_error is None:
+                        first_error = exc
+                finally:
+                    ready_queue.task_done()
+
+        workers = [asyncio.create_task(worker()) for _ in range(_MAX_CONCURRENCY)]
+        try:
+            await ready_queue.join()
+        finally:
+            for w in workers:
+                w.cancel()
 
         if first_error is not None:
             raise first_error

--- a/implementation/python/voxlogica/execution_strategy/lazy.py
+++ b/implementation/python/voxlogica/execution_strategy/lazy.py
@@ -536,6 +536,15 @@ class LazyExecutionStrategy(ExecutionStrategy):
                 if pending[child_id] == 0:
                     ready_queue.put_nowait(child_id)
 
+            if os.environ.get("VOXLOGICA_DEBUG_MEM"):
+                self._dbg = getattr(self, "_dbg", 0) + 1
+                if self._dbg % 300 == 0:
+                    import sys as _sys, resource as _res
+                    rss = _res.getrusage(_res.RUSAGE_SELF).ru_maxrss // 1024
+                    sm = len(prepared.materialization_store._memory) if prepared.materialization_store else -1
+                    pq = prepared.materialization_store._persist_queue.qsize() if prepared.materialization_store else -1
+                    print(f"[mem] fin={self._dbg} values={len(prepared.values)} store_mem={sm} pq={pq} rss={rss}MB", file=_sys.stderr, flush=True)
+
         async def worker() -> None:
             nonlocal first_error
             while True:

--- a/implementation/python/voxlogica/execution_strategy/lazy.py
+++ b/implementation/python/voxlogica/execution_strategy/lazy.py
@@ -437,12 +437,22 @@ class LazyExecutionStrategy(ExecutionStrategy):
         # dependents[p] = list of children that are waiting on p
         dependents: dict[NodeId, list[NodeId]] = defaultdict(list)
         pending: dict[NodeId, int] = {}  # remaining unsatisfied deps within to_compute
+        # consumers[p] = how many to_compute nodes will read p's value. Once that
+        # many have completed, p is no longer needed and its (possibly large) value
+        # is dropped from prepared.values to bound peak memory on wide plans.
+        consumers: dict[NodeId, int] = defaultdict(int)
 
         for nid in to_compute:
-            deps_needed = [d for d in self._get_all_deps(prepared.plan.nodes[nid]) if d in to_compute]
+            all_deps = self._get_all_deps(prepared.plan.nodes[nid])
+            deps_needed = [d for d in all_deps if d in to_compute]
             pending[nid] = len(deps_needed)
             for dep in deps_needed:
                 dependents[dep].append(nid)
+            for dep in all_deps:
+                consumers[dep] += 1
+
+        # Goal values must survive until run() reads them for side-effects.
+        goal_set = set(goal_ids)
 
         ready = [nid for nid, count in pending.items() if count == 0]
 
@@ -488,6 +498,15 @@ class LazyExecutionStrategy(ExecutionStrategy):
                     if self._progress is not None:
                         self._progress.set_postfix_str(node.operator, refresh=False)
                         self._progress.update(1)
+
+                # This node has now consumed its dependencies; free any whose
+                # last consumer has run (kept values stay live in the memo cache).
+                for dep in self._get_all_deps(node):
+                    remaining = consumers.get(dep, 0)
+                    if remaining > 0:
+                        consumers[dep] = remaining - 1
+                        if consumers[dep] == 0 and dep not in goal_set:
+                            prepared.values.pop(dep, None)
 
                 new_ready: list[NodeId] = []
                 for child_id in dependents[nid]:

--- a/implementation/python/voxlogica/execution_strategy/lazy.py
+++ b/implementation/python/voxlogica/execution_strategy/lazy.py
@@ -220,6 +220,7 @@ class LazyExecutionStrategy(ExecutionStrategy):
             prepared.materialization_store.put(nodeId, expression, dependencies, value, metadata={"source": "runtime", "operator": node.operator})
         prepared.completed_nodes.add(nodeId)
         if self._progress is not None:
+            self._progress.set_postfix_str(node.operator, refresh=False)
             self._progress.update(1)
 
     def cache_sequence_item(self, prepared: PreparedPlan, nodeId: NodeId, index:int, value:Any):
@@ -485,6 +486,7 @@ class LazyExecutionStrategy(ExecutionStrategy):
                     # Still mark progress for constants and closures.
                     prepared.completed_nodes.add(nid)
                     if self._progress is not None:
+                        self._progress.set_postfix_str(node.operator, refresh=False)
                         self._progress.update(1)
 
                 new_ready: list[NodeId] = []

--- a/implementation/python/voxlogica/execution_strategy/lazy.py
+++ b/implementation/python/voxlogica/execution_strategy/lazy.py
@@ -376,6 +376,19 @@ class LazyExecutionStrategy(ExecutionStrategy):
             deps.update(self._extract_function_spec_node_ids(spec))
         return deps
 
+    def _cached_exists(self, prepared: PreparedPlan, nid: NodeId) -> bool:
+        """Cheap existence check for a previously-persisted node value.
+
+        Must not materialize the value (that would defeat lazy loading). Only
+        consults the in-RAM memo tier and the backend's existence index.
+        """
+        store = prepared.materialization_store
+        if store is not None and nid in store._memory:
+            return True
+        if self.results_database is not None:
+            return self.results_database.has(nid)
+        return False
+
     def _compute_primitive(self, prepared: PreparedPlan, nid: NodeId) -> Any:
         """Evaluate a single primitive node whose dependencies are already in prepared.values.
 
@@ -430,45 +443,56 @@ class LazyExecutionStrategy(ExecutionStrategy):
         """Async task-graph executor: evaluate all nodes reachable from goal_ids in parallel.
 
         Strategy:
-          1. BFS from goals to find all reachable nodes.
-          2. Pre-populate from cache; exclude already-known nodes.
-          3. Build a reverse-edge dependency graph over nodes still needing computation.
-          4. Seed with zero-in-degree nodes; when a node finishes, decrement its dependents
+          1. BFS from goals to find nodes to compute, pruning at cached subtrees
+             (cached values are loaded lazily, never bulk-pre-loaded into RAM).
+          2. Build a reverse-edge dependency graph over nodes still needing computation.
+          3. Seed with zero-in-degree nodes; when a node finishes, decrement its dependents
              and launch any that become ready.  ITK kernels run in a ThreadPoolExecutor
              (GIL released → true CPU parallelism).  All bookkeeping stays in the event loop.
         """
-        # ── Step 1: find reachable nodes ──────────────────────────────────────
-        reachable: set[NodeId] = set()
+        # Goal values must survive until run() reads them for side-effects.
+        goal_set = set(goal_ids)
+
+        # ── Step 1: find nodes to compute, pruning at cached subtrees ─────────
+        # BFS from the goals, but stop descending whenever a node's value is
+        # already persisted: we will load it lazily on demand and never need its
+        # dependencies. This keeps a re-run from walking (and bulk-loading) the
+        # entire historical DAG, which would blow up memory on wide plans.
+        to_compute: set[NodeId] = set()
+        cached_leaves: set[NodeId] = set()
         queue = list(goal_ids)
+        seen: set[NodeId] = set()
         while queue:
             nid = queue.pop()
-            if nid in reachable:
+            if nid in seen:
                 continue
-            reachable.add(nid)
+            seen.add(nid)
+            if nid in prepared.values:
+                continue
+            # A goal must be materialized for its side-effect even if cached, so
+            # it is always computed/loaded as a graph node (never a pruned leaf).
+            if nid not in goal_set and self._cached_exists(prepared, nid):
+                cached_leaves.add(nid)
+                continue
+            to_compute.add(nid)
             for dep in self._get_all_deps(prepared.plan.nodes[nid]):
-                if dep not in reachable:
+                if dep not in seen:
                     queue.append(dep)
 
-        # ── Step 2: pre-populate from cache ───────────────────────────────────
-        for nid in list(reachable):
-            if nid not in prepared.values:
-                value = self.cache_lookup(prepared, nid)
-                if value is not None:
-                    prepared.values[nid] = value
-
-        # ── Step 3: build dependency graph for uncached nodes ─────────────────
-        to_compute: set[NodeId] = {nid for nid in reachable if nid not in prepared.values}
-
-        # dependents[p] = list of children that are waiting on p
+        # ── Step 2: build dependency graph over the nodes to compute ──────────
+        # dependents[p] = list of children waiting on p (only p in to_compute).
         dependents: dict[NodeId, list[NodeId]] = defaultdict(list)
-        pending: dict[NodeId, int] = {}  # remaining unsatisfied deps within to_compute
-        # consumers[p] = how many to_compute nodes will read p's value. Once that
-        # many have completed, p is no longer needed and its (possibly large) value
-        # is dropped from prepared.values to bound peak memory on wide plans.
+        pending: dict[NodeId, int] = {}  # remaining unsatisfied to_compute deps
+        # consumers[p] = how many to_compute nodes will read p's value (covers
+        # both computed and cached-leaf deps). Once that many have completed, p
+        # is no longer needed and its (possibly large) value is dropped from
+        # prepared.values to bound peak memory on wide plans.
         consumers: dict[NodeId, int] = defaultdict(int)
 
         for nid in to_compute:
             all_deps = self._get_all_deps(prepared.plan.nodes[nid])
+            # Only deps that must still be computed gate readiness; cached-leaf
+            # deps are loaded on demand by the worker just before this node runs.
             deps_needed = [d for d in all_deps if d in to_compute]
             pending[nid] = len(deps_needed)
             for dep in deps_needed:
@@ -476,17 +500,12 @@ class LazyExecutionStrategy(ExecutionStrategy):
             for dep in all_deps:
                 consumers[dep] += 1
 
-        # Goal values must survive until run() reads them for side-effects.
-        goal_set = set(goal_ids)
-
         ready = [nid for nid, count in pending.items() if count == 0]
 
-        if not to_compute:
+        if not to_compute or not ready:
             return
 
-        # ── Step 4: async execution ───────────────────────────────────────────
-        if not ready:
-            return
+        # ── Step 3: async execution ───────────────────────────────────────────
 
         first_error: BaseException | None = None
         loop = asyncio.get_running_loop()
@@ -552,6 +571,12 @@ class LazyExecutionStrategy(ExecutionStrategy):
                 try:
                     if first_error is None:
                         node = prepared.plan.nodes[nid]
+                        # Load any cached-leaf dependencies on demand, in the event
+                        # loop (keeps prepared.values single-writer). Missing deps
+                        # are exactly the cached subtrees pruned in Step 1.
+                        for dep in self._get_all_deps(node):
+                            if dep not in prepared.values:
+                                prepared.values[dep] = self.cache_lookup(prepared, dep)
                         if node.kind == "constant":
                             value = node.attrs.get("value")
                         elif node.kind == "closure":

--- a/implementation/python/voxlogica/execution_strategy/lazy.py
+++ b/implementation/python/voxlogica/execution_strategy/lazy.py
@@ -555,15 +555,6 @@ class LazyExecutionStrategy(ExecutionStrategy):
                 if pending[child_id] == 0:
                     ready_queue.put_nowait(child_id)
 
-            if os.environ.get("VOXLOGICA_DEBUG_MEM"):
-                self._dbg = getattr(self, "_dbg", 0) + 1
-                if self._dbg % 300 == 0:
-                    import sys as _sys, resource as _res
-                    rss = _res.getrusage(_res.RUSAGE_SELF).ru_maxrss // 1024
-                    sm = len(prepared.materialization_store._memory) if prepared.materialization_store else -1
-                    pq = prepared.materialization_store._persist_queue.qsize() if prepared.materialization_store else -1
-                    print(f"[mem] fin={self._dbg} values={len(prepared.values)} store_mem={sm} pq={pq} rss={rss}MB", file=_sys.stderr, flush=True)
-
         async def worker() -> None:
             nonlocal first_error
             while True:

--- a/implementation/python/voxlogica/reducer.py
+++ b/implementation/python/voxlogica/reducer.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Optional, Sequence
 import logging
+import os
 
 from voxlogica.lazy import GoalSpec, NodeId, NodeSpec, SymbolicPlan
 from voxlogica.lazy.ir import OutputKind
@@ -43,6 +44,14 @@ logger = logging.getLogger(__name__)
 
 identifier = str
 Stack = list[tuple[str, str]]
+
+# A `for x in <iterable> do <body>` whose iterable is a compile-time-known constant
+# sequence of length <= this cap is expanded into one DAG node per element, so the
+# async executor can evaluate the bodies in parallel instead of running them
+# sequentially inside a single for_loop kernel. Longer literal lists, and all
+# range()/dir() iterables, fall back to the lazy for_loop node. Override with
+# VOXLOGICA_FOR_EXPANSION_CAP=0 to disable expansion entirely.
+_FOR_EXPANSION_CAP = int(os.environ.get("VOXLOGICA_FOR_EXPANSION_CAP", "4096"))
 
 _PRIMITIVE_OPERATOR_ALIASES: dict[str, str] = {
     "!": "not_compat",
@@ -608,6 +617,30 @@ def _reduce_map_call(
     )
 
 
+def _constant_sequence_elements(
+    work_plan: WorkPlan, node_id: NodeId
+) -> Optional[tuple[NodeId, ...]]:
+    """Return the element node ids if ``node_id`` is a sequence of constants.
+
+    A node qualifies when it is a ``sequence`` primitive (the form emitted for
+    array literals) whose every argument is a ``constant`` node. Returns ``None``
+    otherwise — including for ``range``/``dir`` sequences, whose elements are not
+    materialized as constant nodes at reduce time, so those loops stay lazy.
+    """
+    node = work_plan.nodes.get(node_id)
+    if node is None or node.kind != "primitive":
+        return None
+    if node.operator not in ("sequence", "default.sequence"):
+        return None
+    if node.kwargs:
+        return None
+    for arg_id in node.args:
+        arg = work_plan.nodes.get(arg_id)
+        if arg is None or arg.kind != "constant":
+            return None
+    return tuple(node.args)
+
+
 def reduce_expression(
     env: Environment,
     work_plan: WorkPlan,
@@ -755,6 +788,30 @@ def reduce_expression(
 
     if isinstance(expr, EFor):
         iterable_id = reduce_expression(env, work_plan, expr.iterable, current_stack)
+
+        # Expand the loop when the iterable is a compile-time-known constant
+        # sequence: bind the loop variable to each element's constant node and
+        # re-reduce the body, emitting one DAG node per element. Hash-consing
+        # dedupes subexpressions shared across iterations. See issue #20.
+        element_ids = _constant_sequence_elements(work_plan, iterable_id)
+        if element_ids is not None and 0 <= len(element_ids) <= _FOR_EXPANSION_CAP:
+            body_ids = tuple(
+                reduce_expression(
+                    env.bind(expr.variable, OperationVal(element_id)),
+                    work_plan,
+                    expr.body,
+                    current_stack,
+                )
+                for element_id in element_ids
+            )
+            return _plan_primitive_call(
+                work_plan,
+                identifier="sequence",
+                args=body_ids,
+                output_kind="sequence",
+                position=expr.position,
+            )
+
         closure_id = _create_closure_node(
             variable=expr.variable,
             expression=expr.body,

--- a/implementation/python/voxlogica/reducer.py
+++ b/implementation/python/voxlogica/reducer.py
@@ -694,7 +694,15 @@ def reduce_expression(
         if expr.identifier in {"map", "default.map"} and len(expr.arguments) == 2:
             return _reduce_map_call(env, work_plan, expr, current_stack)
 
-        if expr.identifier in _PRIMITIVE_OPERATOR_ALIASES:
+        # A user-defined function shadows the primitive alias table: resolve it
+        # through the environment below, exactly as the runtime closure path does.
+        # Without this guard the reduce path would force e.g. `!` to the scalar
+        # `not_compat` even where compat.imgql defines `let !(a) = not(a)`, so an
+        # image `!(region)` would compile to a scalar not and feed a bool into
+        # downstream image kernels (e.g. dt). See issue #20.
+        if expr.identifier in _PRIMITIVE_OPERATOR_ALIASES and not isinstance(
+            env.try_find(expr.identifier), FunctionVal
+        ):
             args_ids = tuple(
                 reduce_expression(env, work_plan, arg, current_stack)
                 for arg in expr.arguments

--- a/implementation/python/voxlogica/storage.py
+++ b/implementation/python/voxlogica/storage.py
@@ -33,6 +33,10 @@ STORE_SCHEMA_VERSION = 2
 # Maximum number of value-bearing entries kept in the in-memory cache tier.
 # Overridable via VOXLOGICA_MEMORY_CACHE_CAPACITY for memory-heavy runs.
 DEFAULT_MEMORY_CACHE_CAPACITY = 1024
+# Maximum number of results queued for async persistence before producers block.
+# Bounds peak memory: each queued result pins its (possibly large) value until
+# the persistence thread writes it. Overridable via VOXLOGICA_PERSIST_QUEUE_MAX.
+DEFAULT_PERSIST_QUEUE_MAX = 64
 _RESULTS_TABLE_COLUMNS = frozenset(
     {
         "node_id",
@@ -70,6 +74,18 @@ def _default_memory_capacity() -> int:
         if value > 0:
             return value
     return DEFAULT_MEMORY_CACHE_CAPACITY
+
+
+def _default_persist_queue_max() -> int:
+    raw = os.environ.get("VOXLOGICA_PERSIST_QUEUE_MAX")
+    if raw:
+        try:
+            value = int(raw)
+        except ValueError:
+            value = 0
+        if value > 0:
+            return value
+    return DEFAULT_PERSIST_QUEUE_MAX
 
 
 def results_store_paths(db_path: str | Path | None = None) -> tuple[Path, Path]:
@@ -465,7 +481,9 @@ class MaterializationStore:
         self._read_through = read_through
         self._write_through = write_through
         self._lock = threading.RLock()
-        self._persist_queue: queue.Queue[tuple[str, Any, dict[str, Any]]] = queue.Queue()
+        self._persist_queue: queue.Queue[tuple[str, Any, dict[str, Any]]] = queue.Queue(
+            maxsize=_default_persist_queue_max()
+        )
         self._persist_stop = threading.Event()
         self._persist_thread: threading.Thread | None = None
         if self._backend is not None and self._write_through:
@@ -529,6 +547,7 @@ class MaterializationStore:
             return value
 
     def put(self, node_id: str, expression: Any, dependencies: list[str], value: Any, metadata: dict[str, Any] | None = None) -> None:
+        enqueue: tuple[str, Any, dict[str, Any]] | None = None
         with self._lock:
             record_metadata = dict(metadata or {})
             val,reason,encoded = can_serialize_value(value)
@@ -548,7 +567,23 @@ class MaterializationStore:
                 return
             record_metadata["persisted"] = "pending"
             self._remember(node_id, value)
-            self._persist_queue.put((node_id, value, record_metadata))
+            enqueue = (node_id, value, record_metadata)
+        # Enqueue outside the lock: the bounded queue blocks the producer when
+        # full (backpressure that bounds memory), and the persistence thread
+        # needs the lock to mark items done — holding it here would deadlock.
+        if enqueue is not None:
+            self._persist_queue.put(enqueue)
+
+    def forget(self, node_id: str) -> None:
+        """Drop a value from the in-memory tier once the caller no longer needs it.
+
+        Used by the executor to release intermediates whose every consumer has
+        run. The bookkeeping record is retained (so completed_nodes stays
+        correct); a persisted value remains reloadable from disk, and an
+        un-persisted one is simply recomputed if a later run needs it.
+        """
+        with self._lock:
+            self._memory.pop(node_id, None)
 
     # def fail(self, node_id: str, message: str) -> None:
     #     with self._lock:


### PR DESCRIPTION
Closes #20.

## Summary

Makes the async task-graph executor (#19) actually parallelize the BraTS workloads, and fixes a re-run OOM.

### 1. Constant-iterable `for`-loop expansion (`reducer.py`)
A `for x in <const-seq> do <body>` whose iterable reduces to a sequence of constant nodes is unrolled at reduce time into one DAG node per element (wrapped in a `sequence` node). Previously this compiled to a single `for_loop` kernel that applied the body **sequentially** — so the async executor saw no parallelism. Now the per-element bodies are independent nodes the executor runs concurrently. Hash-consing dedupes shared subexpressions (e.g. a per-case image read shared by all VI levels → one node). `range`/`dir` iterables and lists longer than `VOXLOGICA_FOR_EXPANSION_CAP` (default 4096) keep the lazy `for_loop`.

### 2. Lazy cache loading + subtree pruning (`lazy.py`)
The executor used to pre-populate `prepared.values` with **every** reachable node's persisted value before running — on a re-run of a wide plan this bulk-loaded thousands of cached images into RAM at once and OOM-killed the process deterministically (independent of concurrency). Replaced with cheap existence-based subtree pruning: the BFS stops descending at any already-persisted node, and the worker loads such cached-leaf deps on demand just before the consuming node runs. Cached values enter the live set only at the frontier and are evicted by the existing consumer-count logic.

### 3. `border(img)` / `x(img)` / `y(img)` / `z(img)` (`vox1`)
These zero-arg primitives read image geometry from hidden global `_require_base()` state, which the async executor (no defined evaluation order) could invoke before any image was loaded. They now take the geometry image explicitly, making the dependency visible in the DAG. All call sites updated.

### 4. tqdm node labels
The progress bar shows the operator of the node as it completes.

## Verification
- `brats009` (brats008-pipeline VI-oracle, 15×6 expansion → 7587 nodes) completes; **average_training_oracle = 0.8745** (vs brats008 actual 0.8407 → ~0.034 calibration headroom).
- Memory bounded: fresh run RSS ~2.7 GB, cached re-run RSS flat ~5.7 GB (was OOM at 61 GB before).
- CPU ~9–13 cores busy during sustained run (was ~7 with the pure DFS).
- Expansion correctness: identical output with expansion on vs off (`VOXLOGICA_FOR_EXPANSION_CAP=0`), including nested loops.
- 22 executor/reducer/cache unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)