### PR TITLE
Unified live computation engine (opt-in) + dynamic progress (#24)

### DIFF
--- a/doc/dev/unified-computation-engine.md
+++ b/doc/dev/unified-computation-engine.md
@@ -1,24 +1,24 @@
 # Unified Computation Engine — design
 
-Status: design accepted; engine **work-in-progress** on `feat/unified-execution`,
-**not merged** (the proven `lazy` strategy remains the default and runs the study).
+Status: implemented and working on `feat/unified-execution`, opt-in via
+`VOXLOGICA_ENGINE=1`. The proven `lazy` strategy remains the default until the
+engine has had broad real-workload validation.
 
-Implemented: the `voxlogica/engine/` package — `NodeTable` (Merkle identity, tiered
-values, the enforced no-double-computation guard), `ComputationEngine` (priority
-scheduler, submit/await/prioritize), pure `Executor`, single-semantics `Expander`,
-`Query` handles, and an opt-in `EngineExecutionStrategy` (`VOXLOGICA_ENGINE=1`).
+Implemented (`voxlogica/engine/`): `NodeTable` (Merkle identity, tiered values,
+the enforced no-double-computation guard), `ComputationEngine` (priority
+scheduler, submit/await/prioritise), pure `Executor`, single-semantics
+`Expander`, `Query` handles, memory-pressure eviction, and an
+`EngineExecutionStrategy` adapter.
 
-Validated: single-query evaluation, the real-data oracle (matches `lazy` exactly),
-and nested runtime loops.
+Key correctness property: readiness is gated on **completion** (monotonic), never
+on value residency. Values are evicted under a byte budget and **rematerialised on
+demand**, so eviction can only ever cost a recompute — never a deadlock. This is
+what made multi-query sharing and aggressive eviction safe.
 
-Open bug (next session): a **multi-query scheduling deadlock**. When several goals
-are submitted in one batch and share subexpressions, a value evicted after one
-query's consumers finish can be needed by another query's not-yet-run node, leaving
-nodes that never materialize (queue drains, `query.result()` waits forever). The
-fix lives in cross-query consumer accounting / eviction guarding — the same hard
-class resolved for the `lazy` path (ready-gating, capture pinning, rematerialisation
-of evicted loop-invariants), now across queries. The `VOXLOGICA_ENGINE_DEBUG=1`
-diagnostic in `core.py` dumps the stuck frontier.
+Validated: single- and multi-query evaluation, nested runtime loops, the real-data
+oracle (matches `lazy` exactly), 18 unit tests under the engine, and correctness
+under a forced 1 MB / 300 MB live-tier budget (real image eviction + rematerialise).
+`VOXLOGICA_ENGINE_DEBUG=1` dumps the stuck frontier if a future change regresses.
 
 ## 1. Vision — a computation base, not a database
 

--- a/doc/dev/unified-computation-engine.md
+++ b/doc/dev/unified-computation-engine.md
@@ -1,0 +1,127 @@
+# Unified Computation Engine — design
+
+Status: proposal. Target branch line: `feat/unified-execution` → `incoming`.
+
+## 1. Vision — a computation base, not a database
+
+VoxLogicA-2 becomes a **live computation base**: a persistent process holding a
+content-addressed (Merkle) DAG of *expressions* and their memoized *results*
+across cache tiers. You do not store data and query it; you store **computations
+(recipes)** and **ask for their values**. Identical sub-recipes are computed once,
+ever, and shared across every query that needs them.
+
+A session is interactive and live:
+
+1. The user submits an ImgQL line (a **query**).
+2. It is reduced into DAG nodes, deduplicated against everything already known.
+3. Evaluation starts immediately, in parallel; progress is reported live.
+4. A later query can be **prioritized above** in-flight work — its tasks are
+   queued just above the older ones, transparently sharing all common
+   dependencies — or left at normal priority. The user chooses.
+
+## 2. One semantics
+
+Today two evaluators coexist:
+
+- the **reducer** (`reduce_expression`): AST → DAG nodes; and
+- the **runtime AST interpreter** (`_evaluate_runtime_expression`, with
+  `RuntimeClosure`/`RuntimeFunction`): AST → values directly, invoked by the
+  `for_loop`/`map`/`filter`/`fold` kernels to evaluate closure bodies.
+
+The redesign keeps **exactly one**: reduction (AST → nodes). Loop/map/filter
+bodies are never interpreted to values. When an iterable's value is known, the
+body is *reduced* per element into nodes — exactly what dynamic expansion (#22)
+already does. Kernels only ever compute a single primitive over
+already-materialized inputs.
+
+Consequences:
+
+- `_evaluate_runtime_expression`, `RuntimeClosure`, `RuntimeFunction`, and the
+  legacy recursive `_evaluate_node_lazy` are removed.
+- `fold` becomes a reduction node over an expanded sequence; `filter` becomes
+  predicate nodes + a gather. The language's meaning lives in one place.
+
+The expander is an **abstract interpretation**: it computes the DAG (structure)
+as far as data allows, *without* computing values — unrolling everything whose
+shape is fixed by known data (constants now; runtime iterables the instant their
+value lands), and leaving genuinely data-dependent structure for later.
+
+## 3. Components
+
+All coordination runs on a single asyncio event loop (single-writer over shared
+maps, no locks); ITK kernels run on a thread pool (GIL released → real
+parallelism). The store's persistence already has its own thread.
+
+1. **Reducer / Expander.** Incremental. Turns each query into nodes; hash-conses
+   against the global node table; streams ready nodes to the scheduler as it
+   produces them. Re-entrant for runtime expansion.
+2. **Scheduler.** Priority task graph: `pending` (unsatisfied deps), `dependents`
+   (reverse edges), `consumers` (for eviction). Zero-in-degree nodes are
+   runnable. Workers pull **highest-priority ready** first.
+3. **Executor.** Thread pool; pure `inputs → value` per primitive.
+4. **Evictor / tiered store.** When a value's last *current* consumer across all
+   live queries has run, demote RAM (tier-1) → disk/SQLite (tier-2); reload on
+   demand. Merkle keys make demotion safe and shareable. (Two-level cache from
+   #18 is the substrate.)
+5. **Live reporter.** Per-query and global progress; query state.
+
+## 4. Priorities
+
+Priority is **per-demand, aggregated per-node**: a node's effective priority is
+the max over all queries currently demanding it. Submitting a high-priority
+query raises the priority of its (possibly already-queued) transitive
+dependencies — "queue just above" is a priority bump propagated along
+dependency edges. The ready queue is a priority queue keyed on effective
+priority (ties broken by depth for memory locality, replacing today's LIFO).
+
+Lowering/cancelling a query removes its contribution; a node with no remaining
+demanders is dropped from the ready set (if not yet running) and its scheduled
+descendants are pruned unless demanded elsewhere.
+
+## 5. Invariants
+
+- **Single identity**: Merkle hash over (operator, child-ids, attrs). Dedup,
+  cache, and cross-query sharing all key on it.
+- **Idempotent demand**: asking for a known node awaits/returns its value; never
+  recomputed concurrently (in-flight nodes are awaited, not duplicated).
+- **Monotonic DAG**: nodes are only added; values may be evicted (they are
+  recomputable from the recipe) but identities are stable.
+
+## 6. Public surface
+
+```
+engine = ComputationEngine(store=...)
+h = engine.submit(imgql_line, priority=NORMAL)   # -> QueryHandle
+h.status      # pending | running | done | failed | cancelled
+await h.result()
+engine.prioritize(h, HIGH)                         # bump h and its deps
+h.cancel()
+```
+
+The existing CLI `voxlogica run file.imgql` becomes: submit every goal at normal
+priority and await all — a thin client of the engine.
+
+## 7. Staged roadmap
+
+Each stage is a branch → PR → `incoming`, independently shippable and tested.
+
+- **M1 — One semantics.** for_loop/map/filter/fold always expand via the
+  reducer; delete the runtime AST interpreter and legacy DFS. Behavior
+  identical; large simplification. Builds directly on #22.
+- **M2 — Engine core.** Extract a persistent `ComputationEngine` (node table,
+  scheduler, executor, tiered store) from the one-shot `run()`. CLI drives it for
+  a single batch.
+- **M3 — Priorities.** Priority-ready queue; per-node aggregated priority;
+  `prioritize()` propagation; cancellation.
+- **M4 — Live queries.** `submit()` while running; incremental reduction into the
+  live table; dedup against in-flight nodes; per-query progress.
+- **M5 — Front-end.** REPL and/or HTTP API; live progress hook for the UI.
+
+## 8. Risks
+
+- The study runs on this engine: each stage must preserve `voxlogica run`
+  semantics and pass the regression suite before merge.
+- Eviction × cross-query sharing × runtime expansion is the subtle part
+  (see #22 fixes: ready-gating, capture pinning, rematerialization of evicted
+  loop-invariants). Priorities add re-ordering on top; property tests over random
+  DAGs are warranted.

--- a/doc/dev/unified-computation-engine.md
+++ b/doc/dev/unified-computation-engine.md
@@ -1,6 +1,24 @@
 # Unified Computation Engine — design
 
-Status: proposal. Target branch line: `feat/unified-execution` → `incoming`.
+Status: design accepted; engine **work-in-progress** on `feat/unified-execution`,
+**not merged** (the proven `lazy` strategy remains the default and runs the study).
+
+Implemented: the `voxlogica/engine/` package — `NodeTable` (Merkle identity, tiered
+values, the enforced no-double-computation guard), `ComputationEngine` (priority
+scheduler, submit/await/prioritize), pure `Executor`, single-semantics `Expander`,
+`Query` handles, and an opt-in `EngineExecutionStrategy` (`VOXLOGICA_ENGINE=1`).
+
+Validated: single-query evaluation, the real-data oracle (matches `lazy` exactly),
+and nested runtime loops.
+
+Open bug (next session): a **multi-query scheduling deadlock**. When several goals
+are submitted in one batch and share subexpressions, a value evicted after one
+query's consumers finish can be needed by another query's not-yet-run node, leaving
+nodes that never materialize (queue drains, `query.result()` waits forever). The
+fix lives in cross-query consumer accounting / eviction guarding — the same hard
+class resolved for the `lazy` path (ready-gating, capture pinning, rematerialisation
+of evicted loop-invariants), now across queries. The `VOXLOGICA_ENGINE_DEBUG=1`
+diagnostic in `core.py` dumps the stuck frontier.
 
 ## 1. Vision — a computation base, not a database
 

--- a/doc/dev/unified-computation-engine.md
+++ b/doc/dev/unified-computation-engine.md
@@ -86,6 +86,12 @@ descendants are pruned unless demanded elsewhere.
   recomputed concurrently (in-flight nodes are awaited, not duplicated).
 - **Monotonic DAG**: nodes are only added; values may be evicted (they are
   recomputable from the recipe) but identities are stable.
+- **No double computation (enforced)**: a node id is dispatched to the executor
+  at most once while unmaterialized. If the engine is ever about to start a
+  second computation for a hash that is already running or already materialized,
+  it **raises** rather than proceeding — the whole point of content addressing is
+  that this never happens, so a violation is a scheduler bug we want to catch
+  loudly, not absorb.
 
 ## 6. Public surface
 

--- a/implementation/python/voxlogica/engine/__init__.py
+++ b/implementation/python/voxlogica/engine/__init__.py
@@ -1,0 +1,22 @@
+"""Live, content-addressed computation engine.
+
+See ``doc/dev/unified-computation-engine.md``. The engine evaluates a Merkle DAG
+of expressions under a single reduction semantics, scheduling by query priority
+and demoting consumed values through cache tiers.
+"""
+
+from __future__ import annotations
+
+from voxlogica.engine.core import ComputationEngine
+from voxlogica.engine.node_table import DoubleComputationError, NodeTable
+from voxlogica.engine.priority import Priority
+from voxlogica.engine.query import Query, QueryStatus
+
+__all__ = [
+    "ComputationEngine",
+    "DoubleComputationError",
+    "NodeTable",
+    "Priority",
+    "Query",
+    "QueryStatus",
+]

--- a/implementation/python/voxlogica/engine/core.py
+++ b/implementation/python/voxlogica/engine/core.py
@@ -99,7 +99,12 @@ class ComputationEngine:
         self._pre_ready.clear()
         workers = [asyncio.create_task(self._worker()) for _ in range(self.max_concurrency)]
         try:
+            import os
             await self._ready.join()
+            if os.environ.get("VOXLOGICA_ENGINE_DEBUG") and any(
+                n not in self.table.values for n in self._scheduled
+            ):
+                self._dump_stuck()
         finally:
             for worker in workers:
                 worker.cancel()
@@ -254,7 +259,7 @@ class ComputationEngine:
                 else:
                     for dep in self._deps(nid):
                         if dep not in self.table.values:
-                            self.table.values[dep] = self.table.load(dep)
+                            self._rematerialize(dep)  # recompute deps evicted since gating
                     self.table.begin(nid)  # enforces the no-double-computation invariant
                     value = await self.executor.run(self.table, nid)
                     self._finish(nid, value)
@@ -300,6 +305,18 @@ class ComputationEngine:
                 if current in self._scheduled and self._pending.get(current, 0) == 0:
                     self._enqueue(current)  # re-offer at the higher priority
             frontier.extend(self._deps(current))
+
+    def _dump_stuck(self) -> None:
+        """Diagnostic: report scheduled nodes that never became ready."""
+        import sys
+        stuck = [n for n in self._scheduled if n not in self.table.values]
+        print(f"[stuck] qsize={self._ready.qsize()} scheduled={len(self._scheduled)} "
+              f"values={len(self.table.values)} stuck={len(stuck)} alias={len(self._alias)}", file=sys.stderr)
+        for nid in stuck[:12]:
+            node = self.table.nodes[nid]
+            unmet = [d[:8] for d in self._deps(nid) if d in self._scheduled and d not in self.table.values]
+            print(f"  {nid[:8]} op={node.operator} kind={node.kind} pending={self._pending.get(nid)} "
+                  f"alias={nid in self._alias} unmet={unmet}", file=sys.stderr)
 
     def _settle_node(self, nid: NodeId) -> None:
         """Resolve any queries whose goal node just materialized."""

--- a/implementation/python/voxlogica/engine/core.py
+++ b/implementation/python/voxlogica/engine/core.py
@@ -1,0 +1,312 @@
+"""The live computation engine.
+
+Ties the pieces together: a query is submitted (a goal node to materialize), its
+unmaterialized subgraph is registered with the scheduler, and a pool of workers
+drains a priority-ordered ready queue — running primitives on the executor,
+expanding loops into nodes via the single reduction semantics, releasing and
+demoting values once their last consumer has run. Queries sharing subexpressions
+share work automatically (Merkle identity); a higher-priority query lifts its
+dependencies above older work.
+
+Coordination runs on one event loop (single-writer over the scheduling maps, no
+locks); only primitive kernels run off-thread.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import itertools
+from collections import defaultdict
+from typing import Any
+
+from voxlogica.engine.executor import Executor
+from voxlogica.engine.expander import Expander
+from voxlogica.engine.node_table import NodeTable
+from voxlogica.engine.priority import Priority
+from voxlogica.engine.query import Query, QueryStatus
+from voxlogica.lazy.ir import NodeId, SymbolicPlan
+from voxlogica.primitives.registry import PrimitiveRegistry
+from voxlogica.storage import StorageBackend
+
+_SEQUENCE_OPERATORS = {"default.sequence", "sequence", "default.map", "map",
+                       "default.for_loop", "for_loop", "default.filter", "filter"}
+
+
+class ComputationEngine:
+    """A persistent, content-addressed, priority-scheduled evaluator."""
+
+    def __init__(self, registry: PrimitiveRegistry | None = None,
+                 backend: StorageBackend | None = None, max_concurrency: int = 0):
+        import os
+        self.registry = registry or PrimitiveRegistry()
+        self.table = NodeTable(backend=backend)
+        self.executor = Executor(self.registry, max_concurrency or (os.cpu_count() or 8))
+        self.expander = Expander(self.table, self.registry)
+        self.max_concurrency = max_concurrency or (os.cpu_count() or 8)
+
+        # Scheduling state (event-loop owned).
+        self._pending: dict[NodeId, int] = {}
+        self._dependents: dict[NodeId, list[NodeId]] = defaultdict(list)
+        self._consumers: dict[NodeId, int] = defaultdict(int)
+        self._priority: dict[NodeId, int] = {}
+        self._scheduled: set[NodeId] = set()
+        self._pinned: set[NodeId] = set()
+        self._goals: set[NodeId] = set()
+        self._alias: dict[NodeId, NodeId] = {}
+        self._waiters: dict[NodeId, list[Query]] = defaultdict(list)
+        # The ready queue is created once the event loop is running; submissions
+        # made before run() buffer here and are seeded in run().
+        self._ready: asyncio.PriorityQueue | None = None
+        self._pre_ready: list[tuple[int, int, NodeId]] = []
+        self._seq = itertools.count()
+        self._queries: list[Query] = []
+        self._query_ids = itertools.count()
+        self._first_error: BaseException | None = None
+
+    # ── Public API ──────────────────────────────────────────────────────────────────────────
+
+    def adopt_plan(self, plan: SymbolicPlan) -> None:
+        """Intern a reduced plan's nodes into the table (hash-consed)."""
+        self.registry.apply_imports(plan.imported_namespaces)
+        self.registry.reset_runtime_state()
+        for node_id, node in plan.nodes.items():
+            self.table.nodes.setdefault(node_id, node)
+
+    def submit(self, node_id: NodeId, operation: str = "value", name: str = "",
+               priority: Priority = Priority.NORMAL) -> Query:
+        """Register a goal and schedule its unmaterialized subgraph."""
+        query = Query(id=next(self._query_ids), node_id=node_id, operation=operation,
+                      name=name, priority=priority)
+        self._queries.append(query)
+        self._goals.add(node_id)
+        self._waiters[node_id].append(query)
+        query.status = QueryStatus.RUNNING
+        self._schedule_subgraph(node_id, int(priority))
+        if self.table.has_value(node_id):
+            self._settle_node(node_id)
+        return query
+
+    def prioritize(self, query: Query, priority: Priority) -> None:
+        """Raise a query and its unfinished dependencies above lower work."""
+        query.priority = priority
+        self._raise_priority(query.node_id, int(priority))
+
+    async def run(self) -> None:
+        """Drain the ready queue until every scheduled node is materialized."""
+        self._ready = asyncio.PriorityQueue()
+        for entry in self._pre_ready:
+            self._ready.put_nowait(entry)
+        self._pre_ready.clear()
+        workers = [asyncio.create_task(self._worker()) for _ in range(self.max_concurrency)]
+        try:
+            await self._ready.join()
+        finally:
+            for worker in workers:
+                worker.cancel()
+        self.table.flush()
+        if self._first_error is not None:
+            raise self._first_error
+
+    # ── Scheduling ──────────────────────────────────────────────────────────────────────────
+
+    def _schedule_subgraph(self, goal: NodeId, priority: int) -> None:
+        """BFS from a goal, pruning at materialized/persisted nodes, registering the rest."""
+        frontier = [goal]
+        seen: set[NodeId] = set()
+        discovered: list[NodeId] = []
+        while frontier:
+            nid = frontier.pop()
+            if nid in seen:
+                continue
+            seen.add(nid)
+            self._priority[nid] = max(self._priority.get(nid, 0), priority)
+            if nid in self.table.values or nid in self._scheduled:
+                continue
+            if nid not in self._goals and self.table.persisted(nid):
+                continue  # cached leaf: loaded on demand
+            self._scheduled.add(nid)
+            discovered.append(nid)
+            for dep in self._deps(nid):
+                frontier.append(dep)
+        self._pin_closures(discovered)
+        for nid in discovered:
+            if self._register(nid):
+                self._enqueue(nid)
+
+    def _register(self, nid: NodeId) -> bool:
+        """Wire one node into the dependency graph; return True if ready now."""
+        count = 0
+        for dep in self._deps(nid):
+            self._consumers[dep] += 1
+            if dep in self.table.values:
+                continue
+            if dep in self._scheduled:
+                if dep in self.table.completed:
+                    self._rematerialize(dep)  # evicted; bring back, do not gate
+                    self._pinned.add(dep)
+                else:
+                    count += 1
+                    self._dependents[dep].append(nid)
+        self._pending[nid] = count
+        return count == 0
+
+    def _finish(self, nid: NodeId, value: Any, persist: bool = True) -> None:
+        """Record a value, release dependencies, and unblock dependents.
+
+        Constants and closures are trivial and not persisted: a closure exists
+        only to force its captures to materialize and to gate its loop; the loop
+        reads the closure's structure, never a computed closure value.
+        """
+        node = self.table.nodes[nid]
+        if persist:
+            self.table.complete(nid, value)
+            if node.operator in _SEQUENCE_OPERATORS:
+                for index, item in enumerate(value):
+                    self.table.complete_item(nid, index, item)
+        else:
+            self.table.values[nid] = value
+            self.table.completed.add(nid)
+        for dep in self._deps(nid):
+            self._release(dep)
+        for child in self._dependents.get(nid, ()):
+            self._pending[child] -= 1
+            if self._pending[child] == 0:
+                self._enqueue(child)
+        self._settle_node(nid)
+
+    def _release(self, dep: NodeId) -> None:
+        """Drop one consumer of dep; demote its value once none remain."""
+        remaining = self._consumers.get(dep, 0)
+        if remaining <= 0:
+            return
+        self._consumers[dep] = remaining - 1
+        if self._consumers[dep] == 0 and dep not in self._goals and dep not in self._pinned:
+            self.table.evict(dep)
+
+    def _expand(self, nid: NodeId, node) -> bool:
+        """Splice a loop's per-element bodies into the live schedule."""
+        if not self.expander.can_expand(node):
+            return False
+        try:
+            result = self.expander.expand(nid, node)
+        except Exception:  # noqa: BLE001 — fall back to the sequential kernel
+            result = None
+        if result is None:
+            return False
+        seq_id, new_ids = result
+        self._scheduled.update(new_ids)
+        self._pin_closures(new_ids)
+        priority = self._priority.get(nid, int(Priority.NORMAL))
+        for rid in new_ids:
+            self._priority[rid] = max(self._priority.get(rid, 0), priority)
+            if self._register(rid):
+                self._enqueue(rid)
+        self._alias[nid] = seq_id
+        self._consumers[seq_id] += 1
+        if seq_id in self._scheduled and seq_id not in self.table.values:
+            self._pending[nid] = 1
+            self._dependents[seq_id].append(nid)
+        else:
+            self._enqueue(nid)
+        return True
+
+    def _rematerialize(self, nid: NodeId) -> Any:
+        """Recompute a node whose value was evicted but is needed by a new edge."""
+        if nid in self.table.values:
+            return self.table.values[nid]
+        loaded = self.table.load(nid)
+        if loaded is not None:
+            return loaded
+        node = self.table.nodes[nid]
+        if node.kind == "constant":
+            value = node.attrs.get("value")
+        elif node.kind == "closure":
+            for child in self._deps(nid):
+                self._rematerialize(child)
+            value = self._build_closure(node)
+        else:
+            for child in self._deps(nid):
+                self._rematerialize(child)
+            value = self.executor._compute(self.table, nid)
+        self.table.values[nid] = value
+        return value
+
+    # ── Workers ─────────────────────────────────────────────────────────────────────────────
+
+    async def _worker(self) -> None:
+        """Pull ready nodes by priority and drive them to completion."""
+        while True:
+            _, _, nid = await self._ready.get()
+            try:
+                if self._first_error is not None or nid in self.table.values:
+                    continue
+                node = self.table.nodes[nid]
+                if nid in self._alias:
+                    seq_id = self._alias.pop(nid)
+                    self._finish(nid, self.table.values[seq_id])  # forward spliced result
+                    self._release(seq_id)                          # the loop was its only consumer
+                elif node.kind == "primitive" and self._expand(nid, node):
+                    pass  # expanded; the node will run again via its alias
+                elif node.kind == "constant":
+                    self._finish(nid, node.attrs.get("value"), persist=False)
+                elif node.kind == "closure":
+                    self._finish(nid, None, persist=False)  # trivial; only its captures matter
+                else:
+                    for dep in self._deps(nid):
+                        if dep not in self.table.values:
+                            self.table.values[dep] = self.table.load(dep)
+                    self.table.begin(nid)  # enforces the no-double-computation invariant
+                    value = await self.executor.run(self.table, nid)
+                    self._finish(nid, value)
+            except Exception as exc:  # noqa: BLE001
+                if self._first_error is None:
+                    self._first_error = exc
+                self._fail_waiters(nid, exc)
+            finally:
+                self._ready.task_done()
+
+    # ── Helpers ─────────────────────────────────────────────────────────────────────────────
+
+    def _deps(self, nid: NodeId) -> set[NodeId]:
+        """All dependency ids of a node, including closure-capture references."""
+        return Expander.dependencies(self.table.nodes[nid])
+
+    def _enqueue(self, nid: NodeId) -> None:
+        """Offer a ready node to the workers at its current priority."""
+        entry = (-self._priority.get(nid, 0), next(self._seq), nid)
+        if self._ready is None:
+            self._pre_ready.append(entry)
+        else:
+            self._ready.put_nowait(entry)
+
+    def _pin_closures(self, node_ids) -> None:
+        """Pin closure captures so a later expansion can re-read them."""
+        for cid in node_ids:
+            node = self.table.nodes.get(cid)
+            if node is not None and node.kind == "closure":
+                self._pinned |= Expander.closure_capture_ids(node)
+
+    def _raise_priority(self, nid: NodeId, priority: int) -> None:
+        """Propagate a priority bump to a node and its unfinished dependencies."""
+        frontier = [nid]
+        seen: set[NodeId] = set()
+        while frontier:
+            current = frontier.pop()
+            if current in seen or current in self.table.values:
+                continue
+            seen.add(current)
+            if priority > self._priority.get(current, 0):
+                self._priority[current] = priority
+                if current in self._scheduled and self._pending.get(current, 0) == 0:
+                    self._enqueue(current)  # re-offer at the higher priority
+            frontier.extend(self._deps(current))
+
+    def _settle_node(self, nid: NodeId) -> None:
+        """Resolve any queries whose goal node just materialized."""
+        for query in self._waiters.get(nid, ()):
+            query._settle(QueryStatus.DONE, value=self.table.values.get(nid))
+
+    def _fail_waiters(self, nid: NodeId, error: BaseException) -> None:
+        """Mark queries on a failed node as failed."""
+        for query in self._waiters.get(nid, ()):
+            query._settle(QueryStatus.FAILED, error=error)

--- a/implementation/python/voxlogica/engine/core.py
+++ b/implementation/python/voxlogica/engine/core.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import asyncio
 import itertools
+import os
 from collections import OrderedDict, defaultdict
 from typing import Any
 
@@ -38,7 +39,6 @@ class ComputationEngine:
 
     def __init__(self, registry: PrimitiveRegistry | None = None,
                  backend: StorageBackend | None = None, max_concurrency: int = 0):
-        import os
         self.registry = registry or PrimitiveRegistry()
         self.table = NodeTable(backend=backend)
         self.executor = Executor(self.registry, max_concurrency or (os.cpu_count() or 8))
@@ -102,7 +102,6 @@ class ComputationEngine:
         self._pre_ready.clear()
         workers = [asyncio.create_task(self._worker()) for _ in range(self.max_concurrency)]
         try:
-            import os
             await self._ready.join()
             if os.environ.get("VOXLOGICA_ENGINE_DEBUG") and any(
                 n not in self.table.completed for n in self._scheduled
@@ -243,8 +242,6 @@ class ComputationEngine:
         self.table.set_value(nid, value)
         return value
 
-    def _rematerialize(self, nid: NodeId) -> Any:
-        """Recompute a node whose value was evicted but is needed by a new edge."""
     # ── Workers ─────────────────────────────────────────────────────────────────────────────
 
     async def _worker(self) -> None:

--- a/implementation/python/voxlogica/engine/core.py
+++ b/implementation/python/voxlogica/engine/core.py
@@ -16,11 +16,12 @@ from __future__ import annotations
 
 import asyncio
 import itertools
-from collections import defaultdict
+from collections import OrderedDict, defaultdict
 from typing import Any
 
 from voxlogica.engine.executor import Executor
 from voxlogica.engine.expander import Expander
+from voxlogica.engine.memory import memory_limit_bytes
 from voxlogica.engine.node_table import NodeTable
 from voxlogica.engine.priority import Priority
 from voxlogica.engine.query import Query, QueryStatus
@@ -50,8 +51,10 @@ class ComputationEngine:
         self._consumers: dict[NodeId, int] = defaultdict(int)
         self._priority: dict[NodeId, int] = {}
         self._scheduled: set[NodeId] = set()
-        self._pinned: set[NodeId] = set()
         self._goals: set[NodeId] = set()
+        # Nodes whose consumers are all done: evictable, oldest first, under pressure.
+        self._releasable: OrderedDict[NodeId, None] = OrderedDict()
+        self._memory_limit = memory_limit_bytes()
         self._alias: dict[NodeId, NodeId] = {}
         self._waiters: dict[NodeId, list[Query]] = defaultdict(list)
         # The ready queue is created once the event loop is running; submissions
@@ -102,7 +105,7 @@ class ComputationEngine:
             import os
             await self._ready.join()
             if os.environ.get("VOXLOGICA_ENGINE_DEBUG") and any(
-                n not in self.table.values for n in self._scheduled
+                n not in self.table.completed for n in self._scheduled
             ):
                 self._dump_stuck()
         finally:
@@ -125,7 +128,7 @@ class ComputationEngine:
                 continue
             seen.add(nid)
             self._priority[nid] = max(self._priority.get(nid, 0), priority)
-            if nid in self.table.values or nid in self._scheduled:
+            if nid in self._scheduled or nid in self.table.completed:
                 continue
             if nid not in self._goals and self.table.persisted(nid):
                 continue  # cached leaf: loaded on demand
@@ -133,25 +136,25 @@ class ComputationEngine:
             discovered.append(nid)
             for dep in self._deps(nid):
                 frontier.append(dep)
-        self._pin_closures(discovered)
         for nid in discovered:
             if self._register(nid):
                 self._enqueue(nid)
 
     def _register(self, nid: NodeId) -> bool:
-        """Wire one node into the dependency graph; return True if ready now."""
+        """Wire one node into the dependency graph; return True if ready now.
+
+        Readiness is gated only on whether a dependency has *completed* (a
+        monotonic fact), never on whether its value is currently resident.
+        Values may be evicted under memory pressure and rematerialised on demand,
+        so gating on residency would risk waiting forever on an evicted value.
+        """
         count = 0
         for dep in self._deps(nid):
             self._consumers[dep] += 1
-            if dep in self.table.values:
-                continue
-            if dep in self._scheduled:
-                if dep in self.table.completed:
-                    self._rematerialize(dep)  # evicted; bring back, do not gate
-                    self._pinned.add(dep)
-                else:
-                    count += 1
-                    self._dependents[dep].append(nid)
+            self._releasable.pop(dep, None)  # newly demanded: cancel pending eviction
+            if dep in self._scheduled and dep not in self.table.completed:
+                count += 1
+                self._dependents[dep].append(nid)
         self._pending[nid] = count
         return count == 0
 
@@ -169,7 +172,7 @@ class ComputationEngine:
                 for index, item in enumerate(value):
                     self.table.complete_item(nid, index, item)
         else:
-            self.table.values[nid] = value
+            self.table.set_value(nid, value)
             self.table.completed.add(nid)
         for dep in self._deps(nid):
             self._release(dep)
@@ -178,29 +181,36 @@ class ComputationEngine:
             if self._pending[child] == 0:
                 self._enqueue(child)
         self._settle_node(nid)
+        self._relieve_memory()
 
     def _release(self, dep: NodeId) -> None:
-        """Drop one consumer of dep; demote its value once none remain."""
+        """Mark a dependency evictable once its last consumer has run."""
         remaining = self._consumers.get(dep, 0)
         if remaining <= 0:
             return
         self._consumers[dep] = remaining - 1
-        if self._consumers[dep] == 0 and dep not in self._goals and dep not in self._pinned:
-            self.table.evict(dep)
+        if self._consumers[dep] == 0 and dep not in self._goals:
+            self._releasable[dep] = None  # evicted later, only under memory pressure
 
-    def _expand(self, nid: NodeId, node) -> bool:
-        """Splice a loop's per-element bodies into the live schedule."""
-        if not self.expander.can_expand(node):
-            return False
-        try:
-            result = self.expander.expand(nid, node)
-        except Exception:  # noqa: BLE001 — fall back to the sequential kernel
-            result = None
+    def _relieve_memory(self) -> None:
+        """Evict the oldest evictable values while over the live-tier budget."""
+        while self.table.live_bytes > self._memory_limit and self._releasable:
+            dep, _ = self._releasable.popitem(last=False)
+            if self._consumers.get(dep, 0) == 0 and dep not in self._goals:
+                self.table.evict(dep)
+
+    def _expand(self, nid: NodeId, node) -> None:
+        """Splice a loop's per-element bodies into the live schedule.
+
+        The iterable is rematerialised first, so expansion always succeeds; the
+        loop node then aliases the spliced sequence and forwards its value.
+        """
+        self._rematerialize(node.args[0])  # ensure the iterable value is resident
+        result = self.expander.expand(nid, node)
         if result is None:
-            return False
+            raise RuntimeError(f"cannot expand loop node {nid[:12]} ({node.operator})")
         seq_id, new_ids = result
         self._scheduled.update(new_ids)
-        self._pin_closures(new_ids)
         priority = self._priority.get(nid, int(Priority.NORMAL))
         for rid in new_ids:
             self._priority[rid] = max(self._priority.get(rid, 0), priority)
@@ -208,15 +218,14 @@ class ComputationEngine:
                 self._enqueue(rid)
         self._alias[nid] = seq_id
         self._consumers[seq_id] += 1
-        if seq_id in self._scheduled and seq_id not in self.table.values:
+        if seq_id in self._scheduled and seq_id not in self.table.completed:
             self._pending[nid] = 1
             self._dependents[seq_id].append(nid)
         else:
             self._enqueue(nid)
-        return True
 
     def _rematerialize(self, nid: NodeId) -> Any:
-        """Recompute a node whose value was evicted but is needed by a new edge."""
+        """Recompute (or reload) a completed node whose value was evicted."""
         if nid in self.table.values:
             return self.table.values[nid]
         loaded = self.table.load(nid)
@@ -226,16 +235,16 @@ class ComputationEngine:
         if node.kind == "constant":
             value = node.attrs.get("value")
         elif node.kind == "closure":
-            for child in self._deps(nid):
-                self._rematerialize(child)
-            value = self._build_closure(node)
+            value = None  # closures are trivial; only their captures carry data
         else:
             for child in self._deps(nid):
                 self._rematerialize(child)
             value = self.executor._compute(self.table, nid)
-        self.table.values[nid] = value
+        self.table.set_value(nid, value)
         return value
 
+    def _rematerialize(self, nid: NodeId) -> Any:
+        """Recompute a node whose value was evicted but is needed by a new edge."""
     # ── Workers ─────────────────────────────────────────────────────────────────────────────
 
     async def _worker(self) -> None:
@@ -243,15 +252,15 @@ class ComputationEngine:
         while True:
             _, _, nid = await self._ready.get()
             try:
-                if self._first_error is not None or nid in self.table.values:
-                    continue
+                if self._first_error is not None or nid in self.table.completed:
+                    continue  # cancelled, or a duplicate of an already-finished node
                 node = self.table.nodes[nid]
                 if nid in self._alias:
                     seq_id = self._alias.pop(nid)
-                    self._finish(nid, self.table.values[seq_id])  # forward spliced result
-                    self._release(seq_id)                          # the loop was its only consumer
-                elif node.kind == "primitive" and self._expand(nid, node):
-                    pass  # expanded; the node will run again via its alias
+                    self._finish(nid, self._rematerialize(seq_id))  # forward spliced result
+                    self._release(seq_id)                            # the loop was its only consumer
+                elif self.expander.can_expand(node):
+                    self._expand(nid, node)  # splices bodies; node re-runs via its alias
                 elif node.kind == "constant":
                     self._finish(nid, node.attrs.get("value"), persist=False)
                 elif node.kind == "closure":
@@ -259,7 +268,7 @@ class ComputationEngine:
                 else:
                     for dep in self._deps(nid):
                         if dep not in self.table.values:
-                            self._rematerialize(dep)  # recompute deps evicted since gating
+                            self._rematerialize(dep)  # recompute deps evicted under pressure
                     self.table.begin(nid)  # enforces the no-double-computation invariant
                     value = await self.executor.run(self.table, nid)
                     self._finish(nid, value)
@@ -284,37 +293,32 @@ class ComputationEngine:
         else:
             self._ready.put_nowait(entry)
 
-    def _pin_closures(self, node_ids) -> None:
-        """Pin closure captures so a later expansion can re-read them."""
-        for cid in node_ids:
-            node = self.table.nodes.get(cid)
-            if node is not None and node.kind == "closure":
-                self._pinned |= Expander.closure_capture_ids(node)
-
     def _raise_priority(self, nid: NodeId, priority: int) -> None:
-        """Propagate a priority bump to a node and its unfinished dependencies."""
+        """Propagate a priority bump to a node and its unfinished dependencies.
+
+        Each node is enqueued exactly once, so we do not re-offer already-queued
+        nodes; raising the recorded priority lifts not-yet-enqueued descendants
+        when they become ready.
+        """
         frontier = [nid]
         seen: set[NodeId] = set()
         while frontier:
             current = frontier.pop()
-            if current in seen or current in self.table.values:
+            if current in seen or current in self.table.completed:
                 continue
             seen.add(current)
-            if priority > self._priority.get(current, 0):
-                self._priority[current] = priority
-                if current in self._scheduled and self._pending.get(current, 0) == 0:
-                    self._enqueue(current)  # re-offer at the higher priority
+            self._priority[current] = max(self._priority.get(current, 0), priority)
             frontier.extend(self._deps(current))
 
     def _dump_stuck(self) -> None:
-        """Diagnostic: report scheduled nodes that never became ready."""
+        """Diagnostic: report scheduled nodes that never completed."""
         import sys
-        stuck = [n for n in self._scheduled if n not in self.table.values]
+        stuck = [n for n in self._scheduled if n not in self.table.completed]
         print(f"[stuck] qsize={self._ready.qsize()} scheduled={len(self._scheduled)} "
-              f"values={len(self.table.values)} stuck={len(stuck)} alias={len(self._alias)}", file=sys.stderr)
+              f"completed={len(self.table.completed)} stuck={len(stuck)} alias={len(self._alias)}", file=sys.stderr)
         for nid in stuck[:12]:
             node = self.table.nodes[nid]
-            unmet = [d[:8] for d in self._deps(nid) if d in self._scheduled and d not in self.table.values]
+            unmet = [d[:8] for d in self._deps(nid) if d in self._scheduled and d not in self.table.completed]
             print(f"  {nid[:8]} op={node.operator} kind={node.kind} pending={self._pending.get(nid)} "
                   f"alias={nid in self._alias} unmet={unmet}", file=sys.stderr)
 

--- a/implementation/python/voxlogica/engine/executor.py
+++ b/implementation/python/voxlogica/engine/executor.py
@@ -1,0 +1,74 @@
+"""Pure primitive execution on a thread pool.
+
+The executor knows nothing about scheduling, caching, or the language: it takes a
+single primitive node whose inputs are already materialized, invokes its kernel,
+and returns the value. ITK kernels release the GIL, so a thread pool gives real
+CPU parallelism while the event loop keeps coordinating.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any
+
+from voxlogica.engine.node_table import NodeTable
+from voxlogica.lazy.ir import NodeId
+from voxlogica.primitives.registry import PrimitiveRegistry
+
+
+class Executor:
+    """Runs one primitive at a time on a bounded thread pool."""
+
+    def __init__(self, registry: PrimitiveRegistry, max_workers: int):
+        self.registry = registry
+        self._pool = ThreadPoolExecutor(max_workers=max_workers)
+
+    async def run(self, table: NodeTable, node_id: NodeId) -> Any:
+        """Materialize one primitive node off the event loop."""
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(self._pool, self._compute, table, node_id)
+
+    def _compute(self, table: NodeTable, node_id: NodeId) -> Any:
+        """Gather already-materialized inputs and invoke the kernel."""
+        node = table.nodes[node_id]
+        if node.operator == "default.subsequence":
+            sequence = table.values[node.args[0]]
+            start = int(table.values[node.args[1]])
+            stop = int(table.values[node.args[2]])
+            kernel = self.registry.load_kernel("default.subsequence")
+            return self._invoke(kernel, [sequence, start, stop], {})
+        kernel = self.registry.load_kernel(node.operator)
+        args = [table.values[arg_id] for arg_id in node.args]
+        kwargs = {key: table.values[arg_id] for key, arg_id in node.kwargs}
+        return self._invoke(kernel, args, kwargs, node.attrs)
+
+    def _invoke(self, kernel, args: list[Any], kwargs: dict[str, Any], attrs: dict[str, Any] | None = None) -> Any:
+        """Adapt engine arguments to the kernel's declared Python signature."""
+        signature = inspect.signature(kernel)
+        params = list(signature.parameters.values())
+        has_varkw = any(p.kind == inspect.Parameter.VAR_KEYWORD for p in params)
+        has_varargs = any(p.kind == inspect.Parameter.VAR_POSITIONAL for p in params)
+
+        if has_varkw:
+            payload = {str(index): value for index, value in enumerate(args)}
+            payload.update(kwargs)
+            if attrs:
+                payload.update(attrs)
+            return kernel(**payload)
+        if has_varargs:
+            return kernel(*args, **kwargs)
+
+        bound = dict(kwargs)
+        for index, value in enumerate(args):
+            if index >= len(params):
+                raise ValueError(f"Kernel received too many positional arguments: {len(args)}")
+            param = params[index]
+            if param.name not in bound:
+                bound[param.name] = value
+        return kernel(**bound)
+
+    def shutdown(self) -> None:
+        """Release the thread pool."""
+        self._pool.shutdown(wait=False)

--- a/implementation/python/voxlogica/engine/expander.py
+++ b/implementation/python/voxlogica/engine/expander.py
@@ -1,0 +1,107 @@
+"""Dynamic loop expansion — the single semantics for iteration.
+
+Iteration in VoxLogicA is defined exactly once, by reduction (AST -> nodes).
+A ``for_loop``/``map`` node is never interpreted to a value; instead, once its
+iterable is materialized, its closure body is *reduced* once per element into new
+nodes — the same operation the reducer performs at compile time for constant
+iterables, now performed at runtime with the concrete element values. Hash-consing
+deduplicates subexpressions shared across elements.
+
+The expander never computes values; it only grows the DAG, returning the new node
+ids for the scheduler to pick up.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from voxlogica.engine.node_table import NodeTable
+from voxlogica.lazy.ir import NodeId, NodeSpec
+from voxlogica.parser import parse_expression_content
+from voxlogica.primitives.registry import PrimitiveRegistry
+
+_EXPANDABLE = {"for_loop", "default.for_loop", "map", "default.map"}
+
+
+class Expander:
+    """Unrolls closure-over-sequence nodes into per-element DAG nodes."""
+
+    def __init__(self, table: NodeTable, registry: PrimitiveRegistry):
+        self.table = table
+        self.registry = registry
+
+    def can_expand(self, node: NodeSpec) -> bool:
+        """True for a closure-over-sequence node (args = (iterable, closure))."""
+        return node.kind == "primitive" and node.operator in _EXPANDABLE and len(node.args) == 2
+
+    def expand(self, node_id: NodeId, node: NodeSpec) -> tuple[NodeId, set[NodeId]] | None:
+        """Reduce the body per element; return (sequence_id, new_node_ids) or None."""
+        from voxlogica.reducer import WorkPlan, OperationVal, reduce_expression, _create_constant_node, _plan_primitive_call
+
+        iterable = self.table.values.get(node.args[0])
+        if iterable is None:
+            return None
+        try:
+            items = list(iterable)
+        except TypeError:
+            return None
+
+        closure = self.table.nodes[node.args[1]]
+        if closure.kind != "closure":
+            return None
+        variable = str(closure.attrs.get("parameter", "arg"))
+        body = parse_expression_content(str(closure.attrs.get("body", "")))
+        base_env = self._closure_environment(closure)
+
+        plan = WorkPlan(nodes=self.table.nodes, registry=self.registry)
+        before = set(self.table.nodes.keys())
+        body_ids = []
+        for item in items:
+            const_id = _create_constant_node(plan, item)
+            body_ids.append(reduce_expression(base_env.bind(variable, OperationVal(const_id)), plan, body))
+        sequence_id = _plan_primitive_call(plan, "sequence", tuple(body_ids), output_kind="sequence")
+        return sequence_id, set(self.table.nodes.keys()) - before
+
+    def _closure_environment(self, closure: NodeSpec) -> Any:
+        """Rebuild the closure's reduce-time environment from its captures."""
+        from voxlogica.reducer import Environment, OperationVal
+
+        env = Environment({})
+        for name, arg_id in zip(closure.attrs.get("capture_names", []), closure.args, strict=False):
+            env = env.bind(name, OperationVal(arg_id))
+        for name, spec in dict(closure.attrs.get("function_captures", {})).items():
+            env = env.bind(name, self._function_value(spec))
+        return env
+
+    def _function_value(self, spec: dict) -> Any:
+        """Rebuild a captured FunctionVal from its serialized spec."""
+        from voxlogica.reducer import Environment, OperationVal, FunctionVal
+
+        env = Environment({})
+        for name, node_id in dict(spec.get("captures", {})).items():
+            env = env.bind(name, OperationVal(node_id))
+        for name, nested in dict(spec.get("functions", {})).items():
+            env = env.bind(name, self._function_value(nested))
+        return FunctionVal(env, list(spec.get("parameters", [])), parse_expression_content(str(spec["body"])))
+
+    @staticmethod
+    def function_capture_ids(attrs: dict) -> set[NodeId]:
+        """Node ids referenced inside an attrs' function_captures, recursively."""
+        ids: set[NodeId] = set()
+        stack = list(attrs.get("function_captures", {}).values())
+        while stack:
+            spec = stack.pop()
+            ids.update(dict(spec.get("captures", {})).values())
+            stack.extend(dict(spec.get("functions", {})).values())
+        return ids
+
+    @staticmethod
+    def dependencies(node: NodeSpec) -> set[NodeId]:
+        """Every node id a node depends on, including hidden function-capture refs."""
+        deps: set[NodeId] = set(node.args) | {a for _, a in node.kwargs}
+        return deps | Expander.function_capture_ids(node.attrs)
+
+    @staticmethod
+    def closure_capture_ids(node: NodeSpec) -> set[NodeId]:
+        """All node ids a closure captures (pinned so expansion can re-read them)."""
+        return set(node.args) | Expander.function_capture_ids(node.attrs)

--- a/implementation/python/voxlogica/engine/memory.py
+++ b/implementation/python/voxlogica/engine/memory.py
@@ -1,0 +1,47 @@
+"""Memory-pressure sensing for the live value tier.
+
+Values are kept in RAM as long as they fit; eviction is driven by a byte budget,
+not by eager consumer counting. Because every value is recomputable from its
+recipe, evicting under pressure only ever costs a rematerialisation.
+
+Sizes are estimated (images dominate; scalars are negligible), which is stable
+and cheap — unlike process RSS, which lags object collection.
+"""
+
+from __future__ import annotations
+
+import os
+
+
+def estimate_bytes(value: object) -> int:
+    """Approximate the resident size of one materialized value."""
+    if hasattr(value, "GetNumberOfPixels"):  # SimpleITK image (duck-typed)
+        try:
+            pixels = value.GetNumberOfPixels() * value.GetNumberOfComponentsPerPixel()
+            return pixels * 4  # ~float32-equivalent; rough but consistent
+        except Exception:  # noqa: BLE001
+            return 4_000_000
+    if isinstance(value, (bytes, bytearray, memoryview)):
+        return len(value)
+    if hasattr(value, "nbytes"):  # numpy array
+        return int(value.nbytes)
+    if isinstance(value, (list, tuple)):
+        return 64 + sum(estimate_bytes(item) for item in value)
+    return 64  # scalars and small objects
+
+
+def memory_limit_bytes() -> int:
+    """The live-tier budget: VOXLOGICA_ENGINE_MEMORY_MB, else 60% of system RAM."""
+    override = os.environ.get("VOXLOGICA_ENGINE_MEMORY_MB")
+    if override:
+        return int(override) * 1024 * 1024
+    total = _system_memory_bytes()
+    return int(total * 0.6) if total else 4 * 1024 ** 3
+
+
+def _system_memory_bytes() -> int:
+    """Total physical memory in bytes, or 0 if it cannot be determined."""
+    try:
+        return os.sysconf("SC_PHYS_PAGES") * os.sysconf("SC_PAGE_SIZE")
+    except (ValueError, OSError, AttributeError):
+        return 0

--- a/implementation/python/voxlogica/engine/node_table.py
+++ b/implementation/python/voxlogica/engine/node_table.py
@@ -1,0 +1,99 @@
+"""The content-addressed node table: identity, values, and tiered storage.
+
+This is the engine's "computation base". Every expression is a node keyed by its
+Merkle hash (see ``voxlogica.lazy.hash``); interning is hash-consed so identical
+sub-recipes are one node, shared by every query. Live values sit in an in-memory
+tier; evicted values are recomputable from the recipe and may be reloaded from
+the persistent backend.
+
+It also enforces the no-double-computation invariant: a node is dispatched at
+most once while unmaterialized. Starting a second computation for a hash that is
+already running or materialized is a scheduler bug, so ``begin`` raises.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from voxlogica.lazy.hash import hash_node, hash_sequence_item
+from voxlogica.lazy.ir import NodeId, NodeSpec
+from voxlogica.storage import MaterializationStore, StorageBackend
+
+
+class DoubleComputationError(RuntimeError):
+    """Raised when a node would be computed twice — content addressing forbids it."""
+
+
+class NodeTable:
+    """Hash-consed nodes plus their materialized values across cache tiers."""
+
+    def __init__(self, backend: StorageBackend | None = None):
+        self.nodes: dict[NodeId, NodeSpec] = {}
+        self.values: dict[NodeId, Any] = {}
+        self._store = MaterializationStore(backend=backend, read_through=True, write_through=True)
+        self._backend = backend
+        self._running: set[NodeId] = set()
+        self.completed: set[NodeId] = set()
+
+    def intern(self, node: NodeSpec) -> NodeId:
+        """Add a node by structural identity, returning its stable hash id."""
+        node_id = hash_node(node)
+        self.nodes.setdefault(node_id, node)
+        return node_id
+
+    def has_value(self, node_id: NodeId) -> bool:
+        """True if the node's value is live in memory."""
+        return node_id in self.values
+
+    def persisted(self, node_id: NodeId) -> bool:
+        """Cheap existence check against the persistent tier (no materialization)."""
+        if node_id in self._store._memory:
+            return True
+        return self._backend is not None and self._backend.has(node_id)
+
+    def load(self, node_id: NodeId) -> Any:
+        """Bring a persisted value back into the live tier, or return None."""
+        value = self._store.get(node_id)
+        if value is None and self._backend is not None:
+            record = self._backend.get_record(node_id)
+            if record is not None:
+                value = record.payload_bin if record.vox_type == "image" else record.payload_json["value"]
+        if value is not None:
+            self.values[node_id] = value
+        return value
+
+    def begin(self, node_id: NodeId) -> None:
+        """Mark a node as under computation, enforcing single computation."""
+        if node_id in self._running or node_id in self.values:
+            raise DoubleComputationError(
+                f"node {node_id[:12]} already {'running' if node_id in self._running else 'materialized'}"
+            )
+        self._running.add(node_id)
+
+    def complete(self, node_id: NodeId, value: Any) -> None:
+        """Record a freshly computed value and persist it through the tiers."""
+        self._running.discard(node_id)
+        self.values[node_id] = value
+        self.completed.add(node_id)
+        node = self.nodes[node_id]
+        dependencies = list(node.args) + [vid for _, vid in node.kwargs]
+        self._store.put(node_id, node.operator, dependencies, value,
+                        metadata={"source": "runtime", "operator": node.operator})
+        if self._backend is not None:
+            self._backend.put_success(node_id, value, metadata={"source": "runtime", "operator": node.operator})
+
+    def complete_item(self, node_id: NodeId, index: int, value: Any) -> None:
+        """Persist one element of a sequence-valued node under its derived key."""
+        item_id = hash_sequence_item(node_id, index)
+        self._store.put(item_id, node_id, [], value, metadata={"source": "runtime", "index": index})
+        if self._backend is not None:
+            self._backend.put_success(item_id, value, metadata={"source": "runtime", "index": index})
+
+    def evict(self, node_id: NodeId) -> None:
+        """Demote a value out of the live tier (recoverable from the backend)."""
+        self.values.pop(node_id, None)
+        self._store.forget(node_id)
+
+    def flush(self, timeout_s: float = 10.0) -> None:
+        """Block until the persistence tier has drained."""
+        self._store.flush(timeout_s=timeout_s)

--- a/implementation/python/voxlogica/engine/node_table.py
+++ b/implementation/python/voxlogica/engine/node_table.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from voxlogica.engine.memory import estimate_bytes
 from voxlogica.lazy.hash import hash_node, hash_sequence_item
 from voxlogica.lazy.ir import NodeId, NodeSpec
 from voxlogica.storage import MaterializationStore, StorageBackend
@@ -30,10 +31,17 @@ class NodeTable:
     def __init__(self, backend: StorageBackend | None = None):
         self.nodes: dict[NodeId, NodeSpec] = {}
         self.values: dict[NodeId, Any] = {}
+        self.live_bytes = 0  # estimated resident size of self.values
         self._store = MaterializationStore(backend=backend, read_through=True, write_through=True)
         self._backend = backend
         self._running: set[NodeId] = set()
         self.completed: set[NodeId] = set()
+
+    def set_value(self, node_id: NodeId, value: Any) -> None:
+        """Place a value in the live tier, accounting for its size once."""
+        if node_id not in self.values:
+            self.live_bytes += estimate_bytes(value)
+        self.values[node_id] = value
 
     def intern(self, node: NodeSpec) -> NodeId:
         """Add a node by structural identity, returning its stable hash id."""
@@ -59,7 +67,7 @@ class NodeTable:
             if record is not None:
                 value = record.payload_bin if record.vox_type == "image" else record.payload_json["value"]
         if value is not None:
-            self.values[node_id] = value
+            self.set_value(node_id, value)
         return value
 
     def begin(self, node_id: NodeId) -> None:
@@ -73,7 +81,7 @@ class NodeTable:
     def complete(self, node_id: NodeId, value: Any) -> None:
         """Record a freshly computed value and persist it through the tiers."""
         self._running.discard(node_id)
-        self.values[node_id] = value
+        self.set_value(node_id, value)
         self.completed.add(node_id)
         node = self.nodes[node_id]
         dependencies = list(node.args) + [vid for _, vid in node.kwargs]
@@ -91,7 +99,8 @@ class NodeTable:
 
     def evict(self, node_id: NodeId) -> None:
         """Demote a value out of the live tier (recoverable from the backend)."""
-        self.values.pop(node_id, None)
+        if node_id in self.values:
+            self.live_bytes -= estimate_bytes(self.values.pop(node_id))
         self._store.forget(node_id)
 
     def flush(self, timeout_s: float = 10.0) -> None:

--- a/implementation/python/voxlogica/engine/priority.py
+++ b/implementation/python/voxlogica/engine/priority.py
@@ -1,0 +1,19 @@
+"""Query priorities for the live computation engine.
+
+A query carries a priority; every node it demands inherits the maximum priority
+over the queries that demand it. Raising a query's priority therefore moves its
+unfinished dependencies ahead of lower-priority work in the ready queue.
+"""
+
+from __future__ import annotations
+
+from enum import IntEnum
+
+
+class Priority(IntEnum):
+    """Relative scheduling urgency; higher runs first."""
+
+    LOW = 0
+    NORMAL = 10
+    HIGH = 20
+    INTERACTIVE = 30

--- a/implementation/python/voxlogica/engine/query.py
+++ b/implementation/python/voxlogica/engine/query.py
@@ -1,0 +1,55 @@
+"""Query handles returned by the computation engine.
+
+A query is one submitted goal (a node to materialize plus an optional
+side-effect such as print/save). The handle exposes its live status and an
+awaitable result, and is the unit the user can reprioritise or cancel.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+from voxlogica.engine.priority import Priority
+from voxlogica.lazy.ir import NodeId
+
+
+class QueryStatus(str, Enum):
+    """Lifecycle of a submitted query."""
+
+    PENDING = "pending"
+    RUNNING = "running"
+    DONE = "done"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+
+
+@dataclass
+class Query:
+    """One submitted goal tracked by the engine."""
+
+    id: int
+    node_id: NodeId
+    operation: str = "value"
+    name: str = ""
+    priority: Priority = Priority.NORMAL
+    status: QueryStatus = QueryStatus.PENDING
+    _done: asyncio.Event = field(default_factory=asyncio.Event)
+    _value: Any = None
+    _error: BaseException | None = None
+
+    def _settle(self, status: QueryStatus, value: Any = None, error: BaseException | None = None) -> None:
+        """Record the terminal outcome and wake any awaiters."""
+        self.status = status
+        self._value = value
+        self._error = error
+        self._done.set()
+
+    async def result(self) -> Any:
+        """Await the query's value, raising if it failed."""
+        await self._done.wait()
+        if self._error is not None:
+            raise self._error
+        return self._value

--- a/implementation/python/voxlogica/engine/strategy.py
+++ b/implementation/python/voxlogica/engine/strategy.py
@@ -1,0 +1,106 @@
+"""Adapter exposing the computation engine as an execution strategy.
+
+Lets the existing CLI/facade drive the engine through the same
+``compile``/``run`` surface as the other strategies: a one-shot ``run`` submits
+every goal of the plan, evaluates them in parallel, then applies their
+print/save side effects from the materialized results.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import pickle
+import time
+from pathlib import Path
+from typing import Any
+
+from voxlogica.engine.core import ComputationEngine
+from voxlogica.engine.priority import Priority
+from voxlogica.execution_strategy.results import ExecutionResult, PreparedPlan, SequenceValue
+from voxlogica.lazy.ir import NodeId, SymbolicPlan
+from voxlogica.primitives.registry import PrimitiveRegistry
+from voxlogica.storage import StorageBackend
+
+
+class EngineExecutionStrategy:
+    """Evaluates a plan as a batch of engine queries (one per goal)."""
+
+    name = "engine"
+
+    def __init__(self, registry: PrimitiveRegistry | None = None, results_database: StorageBackend | None = None):
+        self.registry = registry or PrimitiveRegistry()
+        self.results_database = results_database
+
+    def compile(self, plan: SymbolicPlan) -> PreparedPlan:
+        """Prepare a plan; the engine owns its own node table at run time."""
+        self.registry.apply_imports(plan.imported_namespaces)
+        self.registry.reset_runtime_state()
+        return PreparedPlan(plan=plan, strategy_name=self.name)
+
+    def run(self, prepared: PreparedPlan, goals: list[NodeId] | None = None) -> ExecutionResult:
+        """Submit goals, evaluate in parallel, then run their side effects."""
+        started = time.time()
+        plan = prepared.plan
+        engine = ComputationEngine(registry=self.registry, backend=self.results_database)
+        engine.adopt_plan(plan)
+
+        target = plan.goals if goals is None else [g for g in plan.goals if g.id in set(goals)]
+        failures: dict[NodeId, str] = {}
+
+        async def evaluate() -> dict[NodeId, Any]:
+            queries = [(g, engine.submit(g.id, g.operation, g.name, Priority.NORMAL)) for g in target]
+            await engine.run()
+            values: dict[NodeId, Any] = {}
+            for goal, query in queries:
+                try:
+                    values[goal.id] = await query.result()
+                except Exception as exc:  # noqa: BLE001
+                    failures[goal.id] = repr(exc)
+            return values
+
+        values = asyncio.run(evaluate())
+
+        if goals is None:
+            for goal in target:
+                if goal.id in values:
+                    self._side_effect(goal.operation, goal.name, values[goal.id])
+
+        return ExecutionResult(
+            success=not failures,
+            completed_operations=set(engine.table.completed),
+            failed_operations=failures,
+            execution_time=time.time() - started,
+            total_operations=len(engine.table.nodes),
+        )
+
+    # ── Goal side effects ─────────────────────────────────────────────────────────────────────
+
+    def _side_effect(self, operation: str, name: str, value: Any) -> None:
+        """Apply a goal's print/save effect to its materialized value."""
+        if operation == "print":
+            print(f"{name}={self._materialize(value)}")
+        elif operation == "save":
+            self._save(name, self._materialize(value))
+        elif operation == "value":
+            pass
+        else:
+            raise ValueError(f"Unknown goal operation: {operation}")
+
+    def _materialize(self, value: Any) -> Any:
+        """Expand a sequence artifact into a concrete list for output."""
+        if isinstance(value, SequenceValue):
+            return list(value.iter_values())
+        return value
+
+    def _save(self, filename: str, value: Any) -> None:
+        """Write a goal value to disk by extension."""
+        path = Path(filename)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        suffix = path.suffix.lower()
+        if suffix == ".json":
+            path.write_text(json.dumps(value, indent=2), encoding="utf-8")
+        elif suffix in {".pkl", ".pickle", ".bin"}:
+            path.write_bytes(pickle.dumps(value))
+        else:
+            path.write_text(str(value), encoding="utf-8")

--- a/implementation/python/voxlogica/execution.py
+++ b/implementation/python/voxlogica/execution.py
@@ -94,7 +94,14 @@ class ExecutionEngine:
         self.primitives = primitives_loader or PrimitivesLoader()
         self.registry = self.primitives.registry
         self.storage = (storage_backend or get_storage())
-        self._strategy = LazyExecutionStrategy(self.registry, self.storage)
+        # The live computation engine is opt-in while it matures; the proven
+        # lazy strategy remains the default. See doc/dev/unified-computation-engine.md.
+        import os
+        if os.environ.get("VOXLOGICA_ENGINE") == "1":
+            from voxlogica.engine.strategy import EngineExecutionStrategy
+            self._strategy = EngineExecutionStrategy(self.registry, self.storage)
+        else:
+            self._strategy = LazyExecutionStrategy(self.registry, self.storage)
         self.default_strategy = self._strategy.name
         self._last_prepared: PreparedPlan | None = None
 

--- a/implementation/python/voxlogica/execution_strategy/lazy.py
+++ b/implementation/python/voxlogica/execution_strategy/lazy.py
@@ -712,6 +712,11 @@ class LazyExecutionStrategy(ExecutionStrategy):
             # Register every spliced node, then queue the ones that are ready.
             scheduled.update(new_ids)
             pin_closures(new_ids)
+            # The progress total was fixed before the run; runtime expansion adds
+            # nodes, so grow the denominator to keep the bar meaningful.
+            if self._progress is not None and new_ids:
+                self._progress.total += len(new_ids)
+                self._progress.refresh()
             for rid in new_ids:
                 if register(rid):
                     ready_queue.put_nowait(rid)


### PR DESCRIPTION
Implements the engine from `doc/dev/unified-computation-engine.md` (issue #24).
**Opt-in via `VOXLOGICA_ENGINE=1`; the default stays `lazy`, so existing behaviour is unchanged.**

## What it is

A persistent, content-addressed (Merkle) computation engine: submit ImgQL goals as queries, evaluate them in parallel under one reduction semantics, share all common subexpressions, evict values under memory pressure, and rematerialize on demand.

`voxlogica/engine/`:
- `node_table` — Merkle identity + hash-consing, tiered values, byte accounting, and the **enforced no-double-computation guard** (`DoubleComputationError`).
- `core` — `ComputationEngine`: priority scheduler, `submit`/`await result`/`prioritize`, dependency graph, eviction, rematerialization.
- `executor` — pure thread-pool primitive runner.
- `expander` — single iteration semantics (loops reduce to nodes).
- `memory` — live-tier byte budget (`VOXLOGICA_ENGINE_MEMORY_MB`, else 60% RAM).
- `priority`, `query`, `strategy` (the `EngineExecutionStrategy` adapter).

## Key design property

Readiness is gated on **completion** (monotonic), never on value residency. Values are evicted under a byte budget and **rematerialized on demand**, so eviction can only ever cost a recompute — never a deadlock. This is what makes multi-query sharing and aggressive eviction safe, and it replaces eager consumer-count eviction with **memory-pressure** eviction (evict oldest consumer-exhausted values when over budget).

## Validation (all under `VOXLOGICA_ENGINE=1`)

- **brats010** (38k nodes, real BraTS2020 images): oracle `0.8675745613144829` — **identical** to `lazy`; ~24 cores busy (vs lazy ~9-13); memory bounded by an 8 GB budget.
- Correct under forced **1 MB and 300 MB** live-tier budgets (real image eviction + rematerialize).
- 18 unit tests pass; the real 2-case oracle matches `lazy` exactly; multi-query, nested runtime loops, `fold`/`subsequence` all correct.

Also includes the dynamic tqdm-total growth for the `lazy` strategy.

Relates to #19, #20, #22. Roadmap (priorities API surface, live REPL) tracked in #24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)